### PR TITLE
Fixed Update Function not being available in get<T>

### DIFF
--- a/src/caching/GenericCache.ts
+++ b/src/caching/GenericCache.ts
@@ -18,6 +18,9 @@ export default class GenericCache implements ICachingStrategy {
         createFunction: () => Promise<T & ICachable & object>,
         updateFunction?: (item: T) => Promise<T & ICachable & object>
     ): Promise<T & ICachable> {
+        if (updateFunction) {
+            this.updateFunctions.set(cacheKey, updateFunction);
+        }
         const item = await this.get<T>(cacheKey);
         if (item) {
             return item;
@@ -29,9 +32,7 @@ export default class GenericCache implements ICachingStrategy {
         }
 
         this.setCacheItem(cacheKey, newCacheItem);
-        if (updateFunction) {
-            this.updateFunctions.set(cacheKey, updateFunction);
-        }
+        
 
         return newCacheItem;
     }


### PR DESCRIPTION
The first line of the getOrCreate function calls get<T> which needs to call the updateFunction but it would be empty as the updateFunction is only set after the call to get<T>.

Might be a solution for #3 