### PR TITLE
Fix failing tests

### DIFF
--- a/src/endpoints/EpisodesEndpoints.test.ts
+++ b/src/endpoints/EpisodesEndpoints.test.ts
@@ -17,6 +17,12 @@ describe("Integration: Episodes Endpoints", () => {
         const result = await sut.episodes.get(valid.id, "GB");
 
         expect(fetchSpy.request(0).input).toBe(`https://api.spotify.com/v1/episodes/${valid.id}?market=GB`);
+
+        // replace inconsistent properties
+        if (result.show) {
+            result.show.total_episodes = valid.show.total_episodes;
+        }
+
         expect(result).toStrictEqual(valid);
     });
 

--- a/src/test/data/validEpisode.ts
+++ b/src/test/data/validEpisode.ts
@@ -1,6 +1,6 @@
 export function validEpisode() {
     return {
-        audio_preview_url: null,
+        audio_preview_url: "https://podz-content.spotifycdn.com/audio/clips/36PjxCpLUHcAbd49fqxOW1/clip_402900_446200.mp3",
         description: 'Covid-19 hasn’t gone away and, due to travel restrictions, neither has Louis Theroux. In the second outing of his podcast series, he tracks down more high-profile guests he’s been longing to talk to - a fascinating mix of the celebrated, the controversial and the mysterious.    In the last episode of the series, Louis catches up with actor, writer and director Justin Theroux - who also happens to be Louis\'s cousin. With Justin in Mexico and Louis in Texas, they discuss family holidays in Cape Cod, ADHD and the perils of fighting with rocks. .   Producer: Sara Jane Hall   Assistant Producer: Molly Schneider  A Mindhouse production for BBC Radio 4',
         duration_ms: 4259474,
         explicit: true,

--- a/src/test/data/validShow.ts
+++ b/src/test/data/validShow.ts
@@ -166,2059 +166,2056 @@ export function validShow() {
             "VN",
             "VU",
             "WS",
-            "XC",
             "XK",
             "ZA",
             "ZM",
             "ZW"
         ],
-        "copyrights": [
-
-        ],
-        "description": "A podcast looking back at The Simpsons, episode by episode, discussing and analyzing its importance, history, and greatness.",
+        "copyrights": [],
+        "description": "Vi är där historien är. Ansvarig utgivare: Nina Glans",
         "episodes": {
-            "href": "https://api.spotify.com/v1/shows/4ZbloPxqlAqHbbP4EnivIB/episodes?offset=0&limit=50&market=GB",
+            "href": "https://api.spotify.com/v1/shows/38bS44xjbVVZ3No3ByF1dJ/episodes?offset=0&limit=50&market=GB",
             "items": [
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/0b467e7870140b2ffcc0717d28b7a88b370ba05d",
-                    "description": "Tonight, Robbie and Matt are joined by Ryan Rogers (of the Juras-sick Park-cast) to discuss Episode MABF07, Stealing First Base, the fifteenth episode of Season Twenty-One. They talk about Michelle Obama, Sarah Silverman, and Nelson. Listen to the Juras-sick Park-Cast! Support the show on Patreon! Listener Question of the Week: What is your favorite MartinContinue Reading…",
-                    "duration_ms": 6077465,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/3a3c4ab877ecee7d4a235790e860aa72995fcc94",
+                    "description": "Vill du ha sällskap av en nedsupen björn i hängmattan? Hör Vetenskapsradion Historia bläddra bland 1700-talsfiskar, Edith Södergrans fotografier och ryska krigsplaner i sommarens boktipsprogram! Luta dig tillbaka i solstolen och låt Vetenskapsradion Historia tipsa dig om sommarens bästa historiska böcker. Historienördarna Kristina Ekero Eriksson, Urban Björstadius och Tobias Svanelid bläddrar bland drottningar, runristare och nedsupna björnar för att vaska fram guldkornen i vårens historieboksutgivning. Böckerna som tipsas om är:Hedvig Eleonora och hennes tid av Eva Helen UlvrosHotet från Ryssland av Oscar JonssonFienden av Dick HarrisonEn annan Edith av Nina UlmajaKvinnorna, makten, religionen av Jan-Gunnar Rosenblad och Gundel SöderholmBaltikums befrielse av Tobias Berglund och Niclas SennertegFinlands svenska historia av Martin HårdstedtGunila Axén av Jelena ZetterströmPetrus Artedi Ichtyologia av Jakob ChristenssonNationens avskum, militärens elit av Lars Ericson WolkeTyde den som kan av Torun Zachrisson och Magnus KällströmPromenerandets historia av Kekke Stadin",
+                    "duration_ms": 2160000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/2CKKmFPsAHBvsQTAvMi11R"
+                        "spotify": "https://open.spotify.com/episode/5AmVFYRKXAkd10ZRWlBkxu"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/2CKKmFPsAHBvsQTAvMi11R",
-                    "html_description": "<p>Tonight, Robbie and Matt are joined by Ryan Rogers (of the Juras-sick Park-cast) to discuss Episode MABF07, Stealing First Base, the fifteenth episode of Season Twenty-One. They talk about Michelle Obama, Sarah Silverman, and Nelson.</p><br/><p><a href=\"https://jurassickparkcast.blogspot.com/2023/03/episode-45-park.html\" rel=\"nofollow\">Listen to the Juras-sick Park-Cast!</a></p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What is your favorite Martin Prince quote?</p>",
-                    "id": "2CKKmFPsAHBvsQTAvMi11R",
+                    "href": "https://api.spotify.com/v1/episodes/5AmVFYRKXAkd10ZRWlBkxu",
+                    "html_description": "<p>Vill du ha sällskap av en nedsupen björn i hängmattan? Hör Vetenskapsradion Historia bläddra bland 1700-talsfiskar, Edith Södergrans fotografier och ryska krigsplaner i sommarens boktipsprogram!</p> <p>Luta dig tillbaka i solstolen och låt Vetenskapsradion Historia tipsa dig om sommarens bästa historiska böcker. Historienördarna Kristina Ekero Eriksson, Urban Björstadius och Tobias Svanelid bläddrar bland drottningar, runristare och nedsupna björnar för att vaska fram guldkornen i vårens historieboksutgivning.</p><p> </p><p>Böckerna som tipsas om är:</p><p>Hedvig Eleonora och hennes tid av Eva Helen Ulvros</p><p>Hotet från Ryssland av Oscar Jonsson</p><p>Fienden av Dick Harrison</p><p>En annan Edith av Nina Ulmaja</p><p>Kvinnorna, makten, religionen av Jan-Gunnar Rosenblad och Gundel Söderholm</p><p>Baltikums befrielse av Tobias Berglund och Niclas Sennerteg</p><p>Finlands svenska historia av Martin Hårdstedt</p><p>Gunila Axén av Jelena Zetterström</p><p>Petrus Artedi Ichtyologia av Jakob Christensson</p><p>Nationens avskum, militärens elit av Lars Ericson Wolke</p><p>Tyde den som kan av Torun Zachrisson och Magnus Källström</p><p>Promenerandets historia av Kekke Stadin</p>",
+                    "id": "5AmVFYRKXAkd10ZRWlBkxu",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a9936ced0aacbc3bb42766418",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f9936ced0aacbc3bb42766418",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d9936ced0aacbc3bb42766418",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "460 – Stealing First Base (w Ryan Rogers)",
-                    "release_date": "2023-03-13",
+                    "name": "Nedsupen björn i hängmattan?",
+                    "release_date": "2023-06-20",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:2CKKmFPsAHBvsQTAvMi11R"
+                    "uri": "spotify:episode:5AmVFYRKXAkd10ZRWlBkxu"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b2ef78d486fe92b389e59f05c7d88be19c41c0e8",
-                    "description": "Tonight, Matt and Robbie discuss Episode MABF04, Postcards from the Wedge, the fourteenth episode of Season Twenty-One. They talk about homework, abandoned subways, and being better than last week. Support the show on Patreon! Listener Question of the Week: What’s your go-to comfort episode of The Simpsons?",
-                    "duration_ms": 4210070,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/e6883f764d4b237a70d186d9bad4d66ac1e9ed22",
+                    "description": "Ödlepungar, götiska dryckesoffer och yxmördade fornmänniskor samsas i Vetenskapsradion Historias 1000:e program, som sänds inför publik där Tobias Svanelid samlas tre namnkunniga historiker på scenen. Tobias Svanelid firar Vetenskapsradion Historias 1000:e program med en sändning inför publik, där en historikerpanel bland annat diskuterar Sveriges födelse, vikingarnas symbolvärde och vad historieintresse gör med oss människor.Ifrån scenen på Ekermanska malmgården på Södermalm i Stockholm sänds alltså den tusende upplagan av Vetenskapsradion Historia. Ett program som drog igång i januari 2000 och som programletts av Tobias Svanelid.På scenen diskuterar historikern Bo Eriksson och arkeologerna Kristina Ekero Eriksson och Jonathan Lindström Sveriges potentiella födelsedagar och historia, Gustav Vasas despotism och vikingarnas attraktionsvärde och svenskhet. Dessutom hör vi om ödlepungar, götiska dryckesoffer och värdet av historia i en föränderlig tid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/426wSvCcbTdPRIGSzcZSfM"
+                        "spotify": "https://open.spotify.com/episode/5trZFEgnvz1GtWWOmEvc3p"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/426wSvCcbTdPRIGSzcZSfM",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode MABF04, Postcards from the Wedge, the fourteenth episode of Season Twenty-One. They talk about homework, abandoned subways, and being better than last week.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What’s your go-to comfort episode of The Simpsons?</p>",
-                    "id": "426wSvCcbTdPRIGSzcZSfM",
+                    "href": "https://api.spotify.com/v1/episodes/5trZFEgnvz1GtWWOmEvc3p",
+                    "html_description": "<p>Ödlepungar, götiska dryckesoffer och yxmördade fornmänniskor samsas i Vetenskapsradion Historias 1000:e program, som sänds inför publik där Tobias Svanelid samlas tre namnkunniga historiker på scenen.</p> <p>Tobias Svanelid firar Vetenskapsradion Historias 1000:e program med en sändning inför publik, där en historikerpanel bland annat diskuterar Sveriges födelse, vikingarnas symbolvärde och vad historieintresse gör med oss människor.</p><p>Ifrån scenen på Ekermanska malmgården på Södermalm i Stockholm sänds alltså den tusende upplagan av Vetenskapsradion Historia. Ett program som drog igång i januari 2000 och som programletts av Tobias Svanelid.</p><p>På scenen diskuterar historikern Bo Eriksson och arkeologerna Kristina Ekero Eriksson och Jonathan Lindström Sveriges potentiella födelsedagar och historia, Gustav Vasas despotism och vikingarnas attraktionsvärde och svenskhet. Dessutom hör vi om ödlepungar, götiska dryckesoffer och värdet av historia i en föränderlig tid.</p>",
+                    "id": "5trZFEgnvz1GtWWOmEvc3p",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a801fdf1d46d8b6aafc8ad993",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f801fdf1d46d8b6aafc8ad993",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d801fdf1d46d8b6aafc8ad993",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "459 – Postcards from the Wedge",
-                    "release_date": "2023-03-06",
+                    "name": "Vi firar 1000 program!",
+                    "release_date": "2023-06-13",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:426wSvCcbTdPRIGSzcZSfM"
+                    "uri": "spotify:episode:5trZFEgnvz1GtWWOmEvc3p"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/a0603530486d039da110f45a02811a7c88312f3a",
-                    "description": "Tonight, Matt and Robbie talk about Episode MABF06, The Color Yellow, the thirteenth episode of Season Twenty-One. They talk about racism, nonsense, and how easy is it to not write an episode about slavery. Support the show on Patreon! Listener Question of the Week: What episode have you seen the most?",
-                    "duration_ms": 4345628,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/0880e608e3db7dde0721d94e00c967b3ce8bee8a",
+                    "description": "För femhundra år sedan valdes Gustav Eriksson Vasa till svensk kung. Tobias Svanelid återvänder till valplatsen i Strängnäs för att diskutera valet och kungen och hur vi minns Gustav Vasa idag. Utanför Strängnäs domkyrka valdes Gustav Eriksson till Sveriges kung den 6 juni 1523. Tobias Svanelid återvänder till ett nästan heligt landskap där kungavalet ägde rum för femhundra år sedan, på kyrkbacken, i Roggeborgen och de osynliga resterna av Sankt Eskils kapell. Historikern Olle Ferm och Elin Andersson vid Roggeborgen guidar runt vid de mytomspunna platserna och reder ut hur kungavalet gick till, vem som egentligen var hjärnan bakom mötet i Strängnäs och vad Hansestaden Lübeck hade för intresse av en ny svensk kung.Dessutom tecknar historikerna Roger Axelsson och Åsa Karlsson bilden av Gustav Vasa som en maktgirig koleriker, men också en person som höjdes till skyarna av Gustav III och odödliggjordes i såväl Sveriges första kungastaty som 1700-talsoperan Gustav Vasa.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7CXdz8vL5XEjFkAa4p5MgP"
+                        "spotify": "https://open.spotify.com/episode/4lDLntgGQavVxfqPzJqPAn"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7CXdz8vL5XEjFkAa4p5MgP",
-                    "html_description": "<p>Tonight, Matt and Robbie talk about Episode MABF06, The Color Yellow, the thirteenth episode of Season Twenty-One. They talk about racism, nonsense, and how easy is it to not write an episode about slavery.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What episode have you seen the most?</p>",
-                    "id": "7CXdz8vL5XEjFkAa4p5MgP",
+                    "href": "https://api.spotify.com/v1/episodes/4lDLntgGQavVxfqPzJqPAn",
+                    "html_description": "<p>För femhundra år sedan valdes Gustav Eriksson Vasa till svensk kung. Tobias Svanelid återvänder till valplatsen i Strängnäs för att diskutera valet och kungen och hur vi minns Gustav Vasa idag.</p> <p>Utanför Strängnäs domkyrka valdes Gustav Eriksson till Sveriges kung den 6 juni 1523. Tobias Svanelid återvänder till ett nästan heligt landskap där kungavalet ägde rum för femhundra år sedan, på kyrkbacken, i Roggeborgen och de osynliga resterna av Sankt Eskils kapell. Historikern Olle Ferm och Elin Andersson vid Roggeborgen guidar runt vid de mytomspunna platserna och reder ut hur kungavalet gick till, vem som egentligen var hjärnan bakom mötet i Strängnäs och vad Hansestaden Lübeck hade för intresse av en ny svensk kung.</p><p>Dessutom tecknar historikerna Roger Axelsson och Åsa Karlsson bilden av Gustav Vasa som en maktgirig koleriker, men också en person som höjdes till skyarna av Gustav III och odödliggjordes i såväl Sveriges första kungastaty som 1700-talsoperan Gustav Vasa.</p>",
+                    "id": "4lDLntgGQavVxfqPzJqPAn",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aec33e4cbd72c7f6294bf2eb4",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fec33e4cbd72c7f6294bf2eb4",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dec33e4cbd72c7f6294bf2eb4",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "458 – The Color Yellow",
-                    "release_date": "2023-02-27",
+                    "name": "Gustav Vasas kungaval 1523",
+                    "release_date": "2023-06-06",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7CXdz8vL5XEjFkAa4p5MgP"
+                    "uri": "spotify:episode:4lDLntgGQavVxfqPzJqPAn"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f50319865f6a2dc39a9c47a5446e198dc55f5ef8",
-                    "description": "Tonight, Matt and Robbie discuss Episode MABF05, Boy Meets Curl, the twelfth episode of Season Twenty-One. They talk about curling, the Olympics, and pins. Support the show on Patreon! Listener Question of the Week: What’s your favorite Olympic sport?",
-                    "duration_ms": 4306533,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d3de45be4459c6b629d6ce423edfa0e70084433c",
+                    "description": "Innebar valet av Gustav Vasa till svensk kung och det moderna Sveriges födelse? Vetenskapsradion Historia reder ut argumenten kring jubiléet som inte tycks firas så mycket som många hoppats. 6 juni 1523 valdes Gustav Vasa till kung av Sverige. I år menar vissa att händelsen borde uppmärksammas som Sveriges femhundraårsdag, medan kritiker anser att kungavalet inte markerade något principiellt nytt för Sverige.Tobias Svanelid går till botten med femhundraårsdagen och pratar med personerna som vill uppmärksamma kungavalet och försöker förstå varför det stora firandet ändå tycks utebli. Vad säger historikerna i frågan och hur kan en folklorist förklara varför 1523 inte blivit lika viktigt för oss svenskar som 1789 blivit för fransmännen och 1814 för Norge?",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/0Kmq0q8zZDqskTwaVmcIas"
+                        "spotify": "https://open.spotify.com/episode/1VoXREJtZJSp0LStFHaa9o"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/0Kmq0q8zZDqskTwaVmcIas",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode MABF05, Boy Meets Curl, the twelfth episode of Season Twenty-One. They talk about curling, the Olympics, and pins.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What’s your favorite Olympic sport?</p>",
-                    "id": "0Kmq0q8zZDqskTwaVmcIas",
+                    "href": "https://api.spotify.com/v1/episodes/1VoXREJtZJSp0LStFHaa9o",
+                    "html_description": "<p>Innebar valet av Gustav Vasa till svensk kung och det moderna Sveriges födelse? Vetenskapsradion Historia reder ut argumenten kring jubiléet som inte tycks firas så mycket som många hoppats.</p> <p>6 juni 1523 valdes Gustav Vasa till kung av Sverige. I år menar vissa att händelsen borde uppmärksammas som Sveriges femhundraårsdag, medan kritiker anser att kungavalet inte markerade något principiellt nytt för Sverige.</p><p>Tobias Svanelid går till botten med femhundraårsdagen och pratar med personerna som vill uppmärksamma kungavalet och försöker förstå varför det stora firandet ändå tycks utebli. Vad säger historikerna i frågan och hur kan en folklorist förklara varför 1523 inte blivit lika viktigt för oss svenskar som 1789 blivit för fransmännen och 1814 för Norge?</p>",
+                    "id": "1VoXREJtZJSp0LStFHaa9o",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a1721e8d8a5670a661f3c4eac",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f1721e8d8a5670a661f3c4eac",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d1721e8d8a5670a661f3c4eac",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "457 – Boy Meets Curl",
-                    "release_date": "2023-02-20",
+                    "name": "Ska vi fira Sveriges 500-årsdag?",
+                    "release_date": "2023-05-30",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:0Kmq0q8zZDqskTwaVmcIas"
+                    "uri": "spotify:episode:1VoXREJtZJSp0LStFHaa9o"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/c1fb3d28c34f11f53ad8e497f94c04e1090d297d",
-                    "description": "Tonight, Matt and Robbie discuss Episode MABF03, Million Dollar Maybe, the eleventh episode of Season Twenty-One. They talk about filler, nothing, and emptiness. Support the show on Patreon! Listener Question of the Week: What’s your favorite video game console?",
-                    "duration_ms": 4253932,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/342e34870c826032bd71dc0316e2cffab8df2f4b",
+                    "description": "Historia är viktigt för Sverigedemokraterna, och vilka historiska personer och händelser som passar in partiets världsbild analyseras nu av historikern Julia Håkansson. Vikingen, Engelbrekt och Karl XII är Sverigedemokraternas älsklingspersoner i den svenska historien, men på senare år har folkhemmet kommit att ta över rollen som historisk idealbild. Historikern Julia Håkansson är aktuell med en avhandling om Sverigedemokraternas historiesyn och varför historia verkar vara så viktigt för partiet.Dessutom om Tryckfrihetsförordningen 1766 som just utnämnts till ett nytt svenskt världsminne av Unesco. Bok- och bibliotekshistorikern Jonas Nordin beskriver den unika reformen på 1700-talet då Sverige blev först att tillåta yttrandefrihet i en skala som världen aldrig tidigare erfarit.Och så reder Dick Harrison ut varför det bara är brittiska men inga andra monarker som låter kröna sig numera.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/3aFCnxPbr8xHIJMfQdi0xO"
+                        "spotify": "https://open.spotify.com/episode/5MKC7i0cVbXCJiT3TrxuNt"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/3aFCnxPbr8xHIJMfQdi0xO",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode MABF03, Million Dollar Maybe, the eleventh episode of Season Twenty-One. They talk about filler, nothing, and emptiness.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What’s your favorite video game console?</p>",
-                    "id": "3aFCnxPbr8xHIJMfQdi0xO",
+                    "href": "https://api.spotify.com/v1/episodes/5MKC7i0cVbXCJiT3TrxuNt",
+                    "html_description": "<p>Historia är viktigt för Sverigedemokraterna, och vilka historiska personer och händelser som passar in partiets världsbild analyseras nu av historikern Julia Håkansson.</p> <p>Vikingen, Engelbrekt och Karl XII är Sverigedemokraternas älsklingspersoner i den svenska historien, men på senare år har folkhemmet kommit att ta över rollen som historisk idealbild. Historikern Julia Håkansson är aktuell med en avhandling om Sverigedemokraternas historiesyn och varför historia verkar vara så viktigt för partiet.</p><p>Dessutom om Tryckfrihetsförordningen 1766 som just utnämnts till ett nytt svenskt världsminne av Unesco. Bok- och bibliotekshistorikern Jonas Nordin beskriver den unika reformen på 1700-talet då Sverige blev först att tillåta yttrandefrihet i en skala som världen aldrig tidigare erfarit.</p><p>Och så reder Dick Harrison ut varför det bara är brittiska men inga andra monarker som låter kröna sig numera.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "5MKC7i0cVbXCJiT3TrxuNt",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ae17f5a0aaf73a99ae3229cf3",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fe17f5a0aaf73a99ae3229cf3",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68de17f5a0aaf73a99ae3229cf3",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "456 – Million Dollar Maybe",
-                    "release_date": "2023-02-13",
+                    "name": "Så formar Sverigedemokraterna historien",
+                    "release_date": "2023-05-23",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:3aFCnxPbr8xHIJMfQdi0xO"
+                    "uri": "spotify:episode:5MKC7i0cVbXCJiT3TrxuNt"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/97bed0c184b3d34da0f366c89a1ef1fb2878bc2b",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF20, Once Upon a Time in Springfield, the tenth episode of Season Twenty-One. They talk about princesses, gross relationship dynamics, and Krusty. Support the show on Patreon! Listener Question of the Week: What’s your favorite comic strip (including webcomics)?",
-                    "duration_ms": 5457988,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/e25208154c785a438cd87aa2299f911f172062bc",
+                    "description": "Kringresande akrobater, skäggiga damer och kanariefågelspektakel roade 17- och 1800-talets svenskar. Vi tar pulsen på en svunnen nöjeskultur. Och kartlägger handskriftens plågsamma historia. Dresserade kanariefåglar, trollkarlar och akrobater turnerade Sverige runt på 17- och 1800-talet. Dåtidens underhållare var tidens superstjärnor och slipade entreprenörer som nu undersöks av idéhistorikern Leif Runefelt. Vetenskapsradion Historia promenerar tillsammans med honom på Djurgården i Stockholm för att söka efter spåren av dåtidens kringresande underhållningskultur.Dessutom uppmärksammar vi handskriftens plågsamma historia. Såväl medeltidens manuskriptskrivande munkar som 1800-talets skrivkrampande stålpenneskrivare fick lida för konsten att skriva för hand. Litteraturvetaren Thomas Götselius undersöker vad handskriftens historia kan berätta om historiska texter och vår egen tids förhållande till tangentbord, skärmar och hur artificiell intelligens nu författar våra böcker.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/1ckeE9usaNWKds3YwmRhFy"
+                        "spotify": "https://open.spotify.com/episode/27tZeGuSMu1dj6WzN5fDbY"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/1ckeE9usaNWKds3YwmRhFy",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode LABF20, Once Upon a Time in Springfield, the tenth episode of Season Twenty-One. They talk about princesses, gross relationship dynamics, and Krusty.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What’s your favorite comic strip (including webcomics)?</p>",
-                    "id": "1ckeE9usaNWKds3YwmRhFy",
+                    "href": "https://api.spotify.com/v1/episodes/27tZeGuSMu1dj6WzN5fDbY",
+                    "html_description": "<p>Kringresande akrobater, skäggiga damer och kanariefågelspektakel roade 17- och 1800-talets svenskar. Vi tar pulsen på en svunnen nöjeskultur. Och kartlägger handskriftens plågsamma historia.</p> <p>Dresserade kanariefåglar, trollkarlar och akrobater turnerade Sverige runt på 17- och 1800-talet. Dåtidens underhållare var tidens superstjärnor och slipade entreprenörer som nu undersöks av idéhistorikern Leif Runefelt. Vetenskapsradion Historia promenerar tillsammans med honom på Djurgården i Stockholm för att söka efter spåren av dåtidens kringresande underhållningskultur.</p><p>Dessutom uppmärksammar vi handskriftens plågsamma historia. Såväl medeltidens manuskriptskrivande munkar som 1800-talets skrivkrampande stålpenneskrivare fick lida för konsten att skriva för hand. Litteraturvetaren Thomas Götselius undersöker vad handskriftens historia kan berätta om historiska texter och vår egen tids förhållande till tangentbord, skärmar och hur artificiell intelligens nu författar våra böcker.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "27tZeGuSMu1dj6WzN5fDbY",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a6f06c00c48e757d565405b87",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f6f06c00c48e757d565405b87",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d6f06c00c48e757d565405b87",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "455 – Once Upon a Time in Springfield",
-                    "release_date": "2023-02-06",
+                    "name": "Dresserade kanariefåglar roade 1800-talet",
+                    "release_date": "2023-05-16",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:1ckeE9usaNWKds3YwmRhFy"
+                    "uri": "spotify:episode:27tZeGuSMu1dj6WzN5fDbY"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/509146643ca8f5c20dbc710b9cdb6f40683aada3",
-                    "description": "Tonight, Matt and Robbie discuss Episode MABF02, Thursdays with Abie, the ninth episode of Season Twenty-One. They talk about Mitch Albom, human behavior, and Abe Simpson. Support the show on Patreon Listener Question of the Week: What’s your favorite non-fiction book?",
-                    "duration_ms": 4600074,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/518f159e5f4dda284b4611696998c19cdee4a513",
+                    "description": "Skrattspeglar och kortväxta personer skapade succén Liseberg. 100 år efter invigningen besöker vi nöjesfältet som skulle göra Göteborg roligare. Och så uppmärksammar vi okända spionbasen Kari. Krockbilar, bergbanor, dansbanor och ett eget Lilleputtland skulle göra Göteborg roligare och dra folk till staden. Tobias Svanelid besöker 100-årsjubilerande Liseberg som trots invigningsårets regnsommar blev en stor succé och som allt sedan dess roat göteborgare och andra med åkattraktioner, musik och dans.Dessutom uppmärksammar vi de arkeologiska undersökningarna av den första allierade spionbasen på svensk mark under andra världskriget. Mitt under brinnande krig tillät det förment alliansfria Sverige de allierade att anlägga en radiomast och en sabotagebas för norska och allierade spioner i trakterna av Torne träsk. Nu avslöjas vardagslivet på basen, och dess okända historia.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/58mHyrYTwkoA5InfBtUHCN"
+                        "spotify": "https://open.spotify.com/episode/5VArykQcDSfiqaaNqh0o1p"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/58mHyrYTwkoA5InfBtUHCN",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode MABF02, Thursdays with Abie, the ninth episode of Season Twenty-One. They talk about Mitch Albom, human behavior, and Abe Simpson.</p><br/><p>Support the show on Patreon</p><br/><p>Listener Question of the Week: What’s your favorite non-fiction book?</p>",
-                    "id": "58mHyrYTwkoA5InfBtUHCN",
+                    "href": "https://api.spotify.com/v1/episodes/5VArykQcDSfiqaaNqh0o1p",
+                    "html_description": "<p>Skrattspeglar och kortväxta personer skapade succén Liseberg. 100 år efter invigningen besöker vi nöjesfältet som skulle göra Göteborg roligare. Och så uppmärksammar vi okända spionbasen Kari.</p> <p>Krockbilar, bergbanor, dansbanor och ett eget Lilleputtland skulle göra Göteborg roligare och dra folk till staden. Tobias Svanelid besöker 100-årsjubilerande Liseberg som trots invigningsårets regnsommar blev en stor succé och som allt sedan dess roat göteborgare och andra med åkattraktioner, musik och dans.</p><p>Dessutom uppmärksammar vi de arkeologiska undersökningarna av den första allierade spionbasen på svensk mark under andra världskriget. Mitt under brinnande krig tillät det förment alliansfria Sverige de allierade att anlägga en radiomast och en sabotagebas för norska och allierade spioner i trakterna av Torne träsk. Nu avslöjas vardagslivet på basen, och dess okända historia.</p>",
+                    "id": "5VArykQcDSfiqaaNqh0o1p",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a3a95289e736b6562c123a197",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f3a95289e736b6562c123a197",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d3a95289e736b6562c123a197",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "454 – Thursdays with Abie",
-                    "release_date": "2023-01-30",
+                    "name": "Liseberg gjorde Göteborg roligare",
+                    "release_date": "2023-05-09",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:58mHyrYTwkoA5InfBtUHCN"
+                    "uri": "spotify:episode:5VArykQcDSfiqaaNqh0o1p"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/c2aa2f3b2a778576deddbcff798381bd1ab64bb2",
-                    "description": "Tonight, Matt and Robbie discuss Episode MABF01, Oh Brother, Where Bart Thou?, the eighth episode of Season Twenty-One. They talk about Bart, brothers, and the Smothers Brothers. Support the show on Patreon! Listener Question of the Week: What is your idea for a new reoccurring, supporting character?",
-                    "duration_ms": 5266555,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/024bdb6d57cb4a5acecc396fc648992c441705c4",
+                    "description": "Vilka var Sveriges bästa och sämsta kungar och vem hade fulast frisyr? Panelen återsamlas för att debattera kungar genom historien. Och så granskar vi bioaktuella filmen om de tre musketörerna! Historiepanelen träffas för att diskutera kungens 50 år på tronen och listar Sveriges bästa och värsta kungar. Hör om Gustav III som turistguide, om Magnus Erikssons misslyckanden och rikskanslern som var bättre än Gustav II Adolf, men också om Karl IX:s hopplösa frisyr och bibliskt inspirerade lagstiftning.Dessutom går vi på bio för att granska aktuella De tre musketörerna – d’Artagnans historievetenskapliga förtjänster och tillkortakommanden. Historikerna Mats Hallenberg och Magnus Linnarsson gillar filmens ambitioner, men är tveksamma till 1600-talsmusköternas träffsäkerhet.Och så reder Dick Harrison ut om det är vår långa alliansfrihet eller bara ren och skär tur som gjort att Sverige klarat sig undan krig under drygt 200 år.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/2GQ0oFj0cHsHDBOvCad5Tt"
+                        "spotify": "https://open.spotify.com/episode/3BB21jA2vdM6sNVXl0vndg"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/2GQ0oFj0cHsHDBOvCad5Tt",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode MABF01, Oh Brother, Where Bart Thou?, the eighth episode of Season Twenty-One. They talk about Bart, brothers, and the Smothers Brothers.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What is your idea for a new reoccurring, supporting character?</p>",
-                    "id": "2GQ0oFj0cHsHDBOvCad5Tt",
+                    "href": "https://api.spotify.com/v1/episodes/3BB21jA2vdM6sNVXl0vndg",
+                    "html_description": "<p>Vilka var Sveriges bästa och sämsta kungar och vem hade fulast frisyr? Panelen återsamlas för att debattera kungar genom historien. Och så granskar vi bioaktuella filmen om de tre musketörerna!</p> <p>Historiepanelen träffas för att diskutera kungens 50 år på tronen och listar Sveriges bästa och värsta kungar. Hör om Gustav III som turistguide, om Magnus Erikssons misslyckanden och rikskanslern som var bättre än Gustav II Adolf, men också om Karl IX:s hopplösa frisyr och bibliskt inspirerade lagstiftning.</p><p>Dessutom går vi på bio för att granska aktuella De tre musketörerna – d’Artagnans historievetenskapliga förtjänster och tillkortakommanden. Historikerna Mats Hallenberg och Magnus Linnarsson gillar filmens ambitioner, men är tveksamma till 1600-talsmusköternas träffsäkerhet.</p><p>Och så reder Dick Harrison ut om det är vår långa alliansfrihet eller bara ren och skär tur som gjort att Sverige klarat sig undan krig under drygt 200 år.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "3BB21jA2vdM6sNVXl0vndg",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aa2ec8db962dcf68ddb282034",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fa2ec8db962dcf68ddb282034",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68da2ec8db962dcf68ddb282034",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "453 – O Brother, Where Bart Thou?",
-                    "release_date": "2023-01-23",
+                    "name": "De var Sveriges sämsta kungar",
+                    "release_date": "2023-05-02",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:2GQ0oFj0cHsHDBOvCad5Tt"
+                    "uri": "spotify:episode:3BB21jA2vdM6sNVXl0vndg"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/325178fa6f65d0b1b9d66451d7153d81be99194c",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF19, Rednecks and Broomsticks, the seventh episode of Season Twenty-One. They talk about wiccans, hillbilly jokes, and nothing. Support the show on Patreon! Listener Question of the Week: What’s your favorite Neve Campbell movie?",
-                    "duration_ms": 3474787,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/0507794c1e7bb25ad1711cff19b4a931d24269b7",
+                    "description": "En norsk korstågskung steg i land i det påstått hedniska Småland år 1123. Tobias Svanelid undersöker historien kring Kalmare ledung och hur lilla fiskeläget Simrishamn då steg fram i historiens ljus. År 1123 seglade hundratals norska skepp in i Kalmarsund i syfte att kristna de hedniska smålänningarna. Händelsen som gått till historien som Kalmare ledung var mer av en storpolitisk revirmarkering än ett heligt krig, menar historikern Dick Harrison, och fick också konsekvensen att lilla fiskeläget Simrishamn stapplade in i historiens ljus.Tobias Svanelid reser till Simrishamn för att med museichefen Lena Alebo prata om stadens historia, som alltså började för 900 år sedan, och som man firar stort i år. Och så reder vi ut vad som egentligen hände under Kalmare ledung, och hur hedniska smålänningarna egentligen var år 1123.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7GXFYdxl04boIhfqlSAWV5"
+                        "spotify": "https://open.spotify.com/episode/34cKuUWCbsM85VCOE07wYF"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7GXFYdxl04boIhfqlSAWV5",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode LABF19, Rednecks and Broomsticks, the seventh episode of Season Twenty-One. They talk about wiccans, hillbilly jokes, and nothing.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What’s your favorite Neve Campbell movie?</p>",
-                    "id": "7GXFYdxl04boIhfqlSAWV5",
+                    "href": "https://api.spotify.com/v1/episodes/34cKuUWCbsM85VCOE07wYF",
+                    "html_description": "<p>En norsk korstågskung steg i land i det påstått hedniska Småland år 1123. Tobias Svanelid undersöker historien kring Kalmare ledung och hur lilla fiskeläget Simrishamn då steg fram i historiens ljus.</p> <p>År 1123 seglade hundratals norska skepp in i Kalmarsund i syfte att kristna de hedniska smålänningarna. Händelsen som gått till historien som Kalmare ledung var mer av en storpolitisk revirmarkering än ett heligt krig, menar historikern Dick Harrison, och fick också konsekvensen att lilla fiskeläget Simrishamn stapplade in i historiens ljus.</p><p>Tobias Svanelid reser till Simrishamn för att med museichefen Lena Alebo prata om stadens historia, som alltså började för 900 år sedan, och som man firar stort i år. Och så reder vi ut vad som egentligen hände under Kalmare ledung, och hur hedniska smålänningarna egentligen var år 1123.</p>",
+                    "id": "34cKuUWCbsM85VCOE07wYF",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a145e74df87ddae67af4b5454",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f145e74df87ddae67af4b5454",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d145e74df87ddae67af4b5454",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "452 – Rednecks and Broomsticks",
-                    "release_date": "2023-01-16",
+                    "name": "Norges korståg mot Småland",
+                    "release_date": "2023-04-25",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7GXFYdxl04boIhfqlSAWV5"
+                    "uri": "spotify:episode:34cKuUWCbsM85VCOE07wYF"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/51adaa18e802250655f871631848f7685b17e1d8",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF18, Pranks and Greens, the sixth episode of Season Twenty-One. They talk about pranks, Bart, and health food. Support the show on Patreon! Listener Question of the Week: What’s your favorite Jonah Hill movie?",
-                    "duration_ms": 4293032,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/4c0ab334d2fe63f375016b6925a1d137ca1871c2",
+                    "description": "Sverige hade sin egen Biggles! Hör om Gustaf Lönnbergs fantastiska historia i brittiska RAF och hur de svenska piloterna i allierad tjänst stred mot Hitler med glömdes bort av hemlandet. Flera svenskar stred i det brittiska flygvapnet RAF mot Hitlertyskland. I den aktuella boken Svenska flygare mot Hitler, frivilliga i Royal Air Force 1939-45 kartlägger militärhistorikerna Lars Gyllenhaal och Lennart Westberg deras öden och äventyr. Flera av dem blev rikt dekorerade av den brittiska staten, men hemma i Sverige sågs de med misstänksamhet, och deras historia har glömts bort. För lika mycket som svenskarna älskade den fiktive Biggles, lika mycket hade man svårt att förstå sina landsmäns erfarenheter från kriget, berättar Lars Gyllenhaal.Dessutom diskuterar vi surrogatens och livsmedelssubstitutens historia i Sverige. Idag har kaffeprisets uppgång skapat krigsrubriker, men redan på 1700-talet försökte man komma runt de höga kaffepriserna med hjälp av fantasifulla surrogat, berättar historikern Hanna Hodacs som kartlägger surrogathistorien i ett nytt forskningsprojekt.Och så reder Dick Harrison ut historien om våra svenska socknar och hur de egentligen uppstod.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/4dVtv6iW21M5Zuav1GBJdj"
+                        "spotify": "https://open.spotify.com/episode/3bFIYSSgoNnwhMNKyj1Jjb"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/4dVtv6iW21M5Zuav1GBJdj",
-                    "html_description": "<p>Tonight, Matt and Robbie discuss Episode LABF18, Pranks and Greens, the sixth episode of Season Twenty-One. They talk about pranks, Bart, and health food.</p><br/><p>Support the show on Patreon!</p><br/><p>Listener Question of the Week: What’s your favorite Jonah Hill movie?</p>",
-                    "id": "4dVtv6iW21M5Zuav1GBJdj",
+                    "href": "https://api.spotify.com/v1/episodes/3bFIYSSgoNnwhMNKyj1Jjb",
+                    "html_description": "<p>Sverige hade sin egen Biggles! Hör om Gustaf Lönnbergs fantastiska historia i brittiska RAF och hur de svenska piloterna i allierad tjänst stred mot Hitler med glömdes bort av hemlandet.</p> <p>Flera svenskar stred i det brittiska flygvapnet RAF mot Hitlertyskland. I den aktuella boken Svenska flygare mot Hitler, frivilliga i Royal Air Force 1939-45 kartlägger militärhistorikerna Lars Gyllenhaal och Lennart Westberg deras öden och äventyr. Flera av dem blev rikt dekorerade av den brittiska staten, men hemma i Sverige sågs de med misstänksamhet, och deras historia har glömts bort. För lika mycket som svenskarna älskade den fiktive Biggles, lika mycket hade man svårt att förstå sina landsmäns erfarenheter från kriget, berättar Lars Gyllenhaal.</p><p>Dessutom diskuterar vi surrogatens och livsmedelssubstitutens historia i Sverige. Idag har kaffeprisets uppgång skapat krigsrubriker, men redan på 1700-talet försökte man komma runt de höga kaffepriserna med hjälp av fantasifulla surrogat, berättar historikern Hanna Hodacs som kartlägger surrogathistorien i ett nytt forskningsprojekt.</p><p>Och så reder Dick Harrison ut historien om våra svenska socknar och hur de egentligen uppstod.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "3bFIYSSgoNnwhMNKyj1Jjb",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ac73a44acb6f83e1efb29d501",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fc73a44acb6f83e1efb29d501",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dc73a44acb6f83e1efb29d501",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "451 – Pranks and Greens",
-                    "release_date": "2023-01-09",
+                    "name": "Sveriges Biggles",
+                    "release_date": "2023-04-18",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:4dVtv6iW21M5Zuav1GBJdj"
+                    "uri": "spotify:episode:3bFIYSSgoNnwhMNKyj1Jjb"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b1dc8eb7357c93ec9df8f59d7889a8f29743156e",
-                    "description": "Matt and Robbie answer YOUR burning questions in this year’s holiday mailbag!",
-                    "duration_ms": 4461592,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/2e03a48f9b97ba624e39b22e102418bb1338ed2e",
+                    "description": "Blodet från avrättade kunde bota epileptiker och magiska drycker gav bödlar mord i sinnet. I en aktuell bok skildras Sveriges sista bödlar, och vi besöker deras arbetsplats - galgbacken i Stockholm. Ännu en bit in på 1900-talet verkställde bödlar många av de straff som svenskar dömts för. Mitt i det industrialiserade och moderniserade Sverige arbetade denna rest från medeltiden, och präglade sin samtid. Historikern Isak Lidström har undersökt de sista bödlarnas liv i Sverige, och den kultur och många myter som uppstod kring dem, om såväl magiska drycker som heligt blod.Och så rapporterar vi från Vasamuseets nya upptäckt, att en av Vasas besättningsmän inte var båtman, utan – kvinna! Anna Maria Forssberg vid Vasamuseet berättar om kvinnorna på Vasa och vilken roll de spelade i den svenska flottan.Dick Harrison reder dessutom ut vad Hälsingland var för 2500 år sedan.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7xlydBzzACKztXDa3P96cd"
+                        "spotify": "https://open.spotify.com/episode/4cmzSLFanlniua1oqMXR04"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7xlydBzzACKztXDa3P96cd",
-                    "html_description": "Matt and Robbie answer YOUR burning questions in this year’s holiday mailbag!",
-                    "id": "7xlydBzzACKztXDa3P96cd",
+                    "href": "https://api.spotify.com/v1/episodes/4cmzSLFanlniua1oqMXR04",
+                    "html_description": "<p>Blodet från avrättade kunde bota epileptiker och magiska drycker gav bödlar mord i sinnet. I en aktuell bok skildras Sveriges sista bödlar, och vi besöker deras arbetsplats - galgbacken i Stockholm.</p> <p>Ännu en bit in på 1900-talet verkställde bödlar många av de straff som svenskar dömts för. Mitt i det industrialiserade och moderniserade Sverige arbetade denna rest från medeltiden, och präglade sin samtid. Historikern Isak Lidström har undersökt de sista bödlarnas liv i Sverige, och den kultur och många myter som uppstod kring dem, om såväl magiska drycker som heligt blod.</p><p>Och så rapporterar vi från Vasamuseets nya upptäckt, att en av Vasas besättningsmän inte var båtman, utan – kvinna! Anna Maria Forssberg vid Vasamuseet berättar om kvinnorna på Vasa och vilken roll de spelade i den svenska flottan.</p><p>Dick Harrison reder dessutom ut vad Hälsingland var för 2500 år sedan.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "4cmzSLFanlniua1oqMXR04",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a84b623b50fbac9202c548519",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f84b623b50fbac9202c548519",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d84b623b50fbac9202c548519",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "450 – Holiday Mailbag 2022",
-                    "release_date": "2022-12-26",
+                    "name": "De sista bödlarna",
+                    "release_date": "2023-04-11",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7xlydBzzACKztXDa3P96cd"
+                    "uri": "spotify:episode:4cmzSLFanlniua1oqMXR04"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/23a3363c11ccb346b443624ad90ef0db9c82e068",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF17, The Devil Wears Nada, the fifth episode of Season Twenty-One. They talk about pin-up calendars, Fission Week, and cooking with Flanders. Support the show on Patreon! Listener Question of the Week: What’s your favorite Carl quote?",
-                    "duration_ms": 4477470,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d21eddadf749ec1937b2f26720fa2d10948ce3fe",
+                    "description": "I slutet av 1700-talet gick de politiska och känslomässiga svallvågorna höga. Men hur klarade dåtidens politiker av att anpassa sig till revolutionernas tidevarv? Ny forskning ger svar. I en känslostormande tid måste också politiken tala till hjärtat snarare än till hjärnan. Så tycks det sena 1700-talets brittiska politiker ha resonerat när de stred om landets framtid i revolutionernas tidevarv. Historikern Alvar Blomgren har undersökt hur känslostormarna under Franska revolutionen omsattes till politisk verklighet och vilka nya krav på känslomässighet och utlevande gester som ställdes på den tidens politiker. Och vad som lever kvar av tankarna idag.Dessutom reder Dick Harrison ut vad som lever kvar av det romerska imperiet i dagens katolska kyrka.Programledare är Tobias Svanelid. ",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7szZ1mRnhn5NBx9uraxzHP"
+                        "spotify": "https://open.spotify.com/episode/6rMBMF5ZETBWhFcMAK6ZCJ"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7szZ1mRnhn5NBx9uraxzHP",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF17, The Devil Wears Nada, the fifth episode of Season Twenty-One. They talk about pin-up calendars, Fission Week, and cooking with Flanders. Support the show on Patreon! Listener Question of the Week: What’s your favorite Carl quote?",
-                    "id": "7szZ1mRnhn5NBx9uraxzHP",
+                    "href": "https://api.spotify.com/v1/episodes/6rMBMF5ZETBWhFcMAK6ZCJ",
+                    "html_description": "<p>I slutet av 1700-talet gick de politiska och känslomässiga svallvågorna höga. Men hur klarade dåtidens politiker av att anpassa sig till revolutionernas tidevarv? Ny forskning ger svar.</p> <p>I en känslostormande tid måste också politiken tala till hjärtat snarare än till hjärnan. Så tycks det sena 1700-talets brittiska politiker ha resonerat när de stred om landets framtid i revolutionernas tidevarv. Historikern Alvar Blomgren har undersökt hur känslostormarna under Franska revolutionen omsattes till politisk verklighet och vilka nya krav på känslomässighet och utlevande gester som ställdes på den tidens politiker. Och vad som lever kvar av tankarna idag.</p><p>Dessutom reder Dick Harrison ut vad som lever kvar av det romerska imperiet i dagens katolska kyrka.</p><p>Programledare är Tobias Svanelid. </p>",
+                    "id": "6rMBMF5ZETBWhFcMAK6ZCJ",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a03ef80ecb5ed4635ea4e71d0",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f03ef80ecb5ed4635ea4e71d0",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d03ef80ecb5ed4635ea4e71d0",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "449 – The Devil Wears Nada",
-                    "release_date": "2022-12-19",
+                    "name": "När känslorna kom in i politiken",
+                    "release_date": "2023-04-04",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7szZ1mRnhn5NBx9uraxzHP"
+                    "uri": "spotify:episode:6rMBMF5ZETBWhFcMAK6ZCJ"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f1937d98a8ad13835ea6eba2d5e5d6e120c5ae5f",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF14, Treehouse of Horror XX, the fourth episode of Season Twenty-One. They talk about Hitchcock, zombies, and strange songs. Support the show on Patreon! Listener Question of the Week: What’s your favorite Hitchcock film?",
-                    "duration_ms": 4172766,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/398ef10b737e9883a780f6a87b1ff931b172ac14",
+                    "description": "Varför har relationen mellan Sverige och Ryssland stadigt blivit sämre det senaste årtusendet? Dick Harrison gästar Tobias Svanelid, liksom krigsvetaren Oscar Jonsson, aktuell med Hotet från Ryssland. Det började med striderna om Finland och Baltikum på 1200-talet och urartade totalt med Johan III:s ”skällebrev” till Ivan den Förskräcklige. 1700-talets våldsamma ryska påverkanskampanjer mot Sverige och den svenska russofobin under 1800-talet cementerade osämjan. Sveriges relation till Ryssland har präglats av fiendskap och främlingskap och i den nya boken Fienden analyserar Dick Harrison orsakerna till den dåliga stämningen länderna emellan.Hur hotet från Ryssland ska förstås undersöks också av Oscar Jonsson, doktor i krigsvetenskap och expert på rysk krigföring i aktuella Hotet från Ryssland. Att bevara regimens maktställning är en av nyckelpunkterna i Putins strategi som vi behöver förstå för att greppa invasionen av Ukraina säger han.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/57yXA2phndXGP7gaznzNKQ"
+                        "spotify": "https://open.spotify.com/episode/0rfsnLOftzct0mi0MC44Xa"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/57yXA2phndXGP7gaznzNKQ",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF14, Treehouse of Horror XX, the fourth episode of Season Twenty-One. They talk about Hitchcock, zombies, and strange songs. Support the show on Patreon! Listener Question of the Week: What’s your favorite Hitchcock film?",
-                    "id": "57yXA2phndXGP7gaznzNKQ",
+                    "href": "https://api.spotify.com/v1/episodes/0rfsnLOftzct0mi0MC44Xa",
+                    "html_description": "<p>Varför har relationen mellan Sverige och Ryssland stadigt blivit sämre det senaste årtusendet? Dick Harrison gästar Tobias Svanelid, liksom krigsvetaren Oscar Jonsson, aktuell med Hotet från Ryssland.</p> <p>Det började med striderna om Finland och Baltikum på 1200-talet och urartade totalt med Johan III:s ”skällebrev” till Ivan den Förskräcklige. 1700-talets våldsamma ryska påverkanskampanjer mot Sverige och den svenska russofobin under 1800-talet cementerade osämjan. Sveriges relation till Ryssland har präglats av fiendskap och främlingskap och i den nya boken Fienden analyserar Dick Harrison orsakerna till den dåliga stämningen länderna emellan.</p><p>Hur hotet från Ryssland ska förstås undersöks också av Oscar Jonsson, doktor i krigsvetenskap och expert på rysk krigföring i aktuella Hotet från Ryssland. Att bevara regimens maktställning är en av nyckelpunkterna i Putins strategi som vi behöver förstå för att greppa invasionen av Ukraina säger han.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "0rfsnLOftzct0mi0MC44Xa",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a1f46bc45fdccabe76730573e",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f1f46bc45fdccabe76730573e",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d1f46bc45fdccabe76730573e",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "448 – Treehouse of Horror XX",
-                    "release_date": "2022-12-12",
+                    "name": "Ryssland har varit Sveriges eviga fiende",
+                    "release_date": "2023-03-28",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:57yXA2phndXGP7gaznzNKQ"
+                    "uri": "spotify:episode:0rfsnLOftzct0mi0MC44Xa"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/c6fc5f1a0d4bfd2277936ba36c23c8c4b4a6bf6d",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF16, The Great Wife Hope, the third episode of Season Twenty-One. They talk about MMA, Marge’s kindness, and a complete and total lack of sincerity from The Simpsons. Support the show on Patreon! Listener Question of the Week: What is your favorite moment of cartoon violence in The Simpsons?",
-                    "duration_ms": 5075550,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/671c90202a45fcb769e818eaa8fe078eb9d2bc5f",
+                    "description": "Privata mattanter, fängelsehålor och tiggeri präglade de första svenska gymnasieelevernas vardag. Tobias Svanelid besöker 400-årsjublierande gymnasiet i Västerås, stormaktstidens bildningsprojekt. 1623 välkomnades de första eleverna till Västerås gymnasium, den svenska stormaktstidens nya flaggskepp för bildning som skulle utbilda nyttiga medborgare till statsförvaltningen. Vetenskapsradion Historia reser dit med historikern Pontus Folkesson för att leva sig in i de första gymnasieelevernas vardag, med privatanställda mattanter, stränga straff i fängelsehålan ”Proban” och dåtidens studiestödssystem – djäknegången, som ofta ledde till bråk och sen ankomst.Dessutom hör vi om hur 400-årsjubiléet ska firas och hur skolans traditioner än idag upprätthålls av Arosbröderna, Sveriges äldsta skolförening.Och så berättar ukrainska bibliotekarien Tetiana Chorna som nyligen varit på Sverigebesök om situationen för Ukrainas hotade bibliotek. Omkring 400 bibliotek har redan skadats eller förstörts i kriget och nu satsar man på digitaliseringsprojekt för att rädda landets bokskatter.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/3GiZhhkiXymJZ32sCFnttp"
+                        "spotify": "https://open.spotify.com/episode/3mqR2AyxofEZjt3jKNeyb5"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/3GiZhhkiXymJZ32sCFnttp",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF16, The Great Wife Hope, the third episode of Season Twenty-One. They talk about MMA, Marge’s kindness, and a complete and total lack of sincerity from The Simpsons. Support the show on Patreon! Listener Question of the Week: What is your favorite moment of cartoon violence in The Simpsons?",
-                    "id": "3GiZhhkiXymJZ32sCFnttp",
+                    "href": "https://api.spotify.com/v1/episodes/3mqR2AyxofEZjt3jKNeyb5",
+                    "html_description": "<p>Privata mattanter, fängelsehålor och tiggeri präglade de första svenska gymnasieelevernas vardag. Tobias Svanelid besöker 400-årsjublierande gymnasiet i Västerås, stormaktstidens bildningsprojekt.</p> <p>1623 välkomnades de första eleverna till Västerås gymnasium, den svenska stormaktstidens nya flaggskepp för bildning som skulle utbilda nyttiga medborgare till statsförvaltningen. Vetenskapsradion Historia reser dit med historikern Pontus Folkesson för att leva sig in i de första gymnasieelevernas vardag, med privatanställda mattanter, stränga straff i fängelsehålan ”Proban” och dåtidens studiestödssystem – djäknegången, som ofta ledde till bråk och sen ankomst.</p><p>Dessutom hör vi om hur 400-årsjubiléet ska firas och hur skolans traditioner än idag upprätthålls av Arosbröderna, Sveriges äldsta skolförening.</p><p>Och så berättar ukrainska bibliotekarien Tetiana Chorna som nyligen varit på Sverigebesök om situationen för Ukrainas hotade bibliotek. Omkring 400 bibliotek har redan skadats eller förstörts i kriget och nu satsar man på digitaliseringsprojekt för att rädda landets bokskatter.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "3mqR2AyxofEZjt3jKNeyb5",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a664e5fbe026e4484de40e45f",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f664e5fbe026e4484de40e45f",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d664e5fbe026e4484de40e45f",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "447 – The Great Wife Hope",
-                    "release_date": "2022-12-05",
+                    "name": "Sveriges första gymnasieskola",
+                    "release_date": "2023-03-21",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:3GiZhhkiXymJZ32sCFnttp"
+                    "uri": "spotify:episode:3mqR2AyxofEZjt3jKNeyb5"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/eec0e49847bab1bd5f5cf94544b12f29ada37651",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF15, Bart Gets a Z, the second episode of Season Twenty-One. They talk about Edna, cell phones, and muffin stores. Buy Robbie’s new book, The Other! Support the show on Patreon Listener Question of the Week: What’s your favorite Edna Krabappel quote?",
-                    "duration_ms": 4947785,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/94afe36cf22748cd4d34e7bd259861fa340ec369",
+                    "description": "Vilka var stenålderns gropkeramiker som levde längs Skandinaviens kuster? Vi uppmärksammar forskningen om säljägarna i Ajvide på Gotland där jägar- och fiskekulturen frodades för 5000 år sedan. De vägrade bli bönder och valde istället att fiska och jaga säl längs Skandinaviens kuster. I gotländska Ajvide finns de bäst bevarade resterna av den gropkeramiska kulturen, som för 5000 år sedan dominerade våra kuster och som inte ville beblanda sig särskilt mycket med jordbrukarna i inlandet. Tobias Svanelid uppmärksammar den aktuella forskning som nu försöker förstå sig på gropkeramikerna bättre och som bland det enorma skelettmaterialet ifrån Ajvide hittar tecken på enorma grisfester, igelkottsdyrkan och en envishet att hålla kvar vid sin egen livsstil i konkurrens med bönderna.Dessutom svarar Dick Harrison på en lyssnarfråga om hur det kunde gå så snabbt när islam spreds över Europa och Asien under medeltiden.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/4N0govIwm1jIKL6M3Sp5Fs"
+                        "spotify": "https://open.spotify.com/episode/2JIxVl3WyaeXYH6VRi49C8"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/4N0govIwm1jIKL6M3Sp5Fs",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF15, Bart Gets a Z, the second episode of Season Twenty-One. They talk about Edna, cell phones, and muffin stores. Buy Robbie’s new book, The Other! Support the show on Patreon Listener Question of the Week: What’s your favorite Edna Krabappel quote?",
-                    "id": "4N0govIwm1jIKL6M3Sp5Fs",
+                    "href": "https://api.spotify.com/v1/episodes/2JIxVl3WyaeXYH6VRi49C8",
+                    "html_description": "<p>Vilka var stenålderns gropkeramiker som levde längs Skandinaviens kuster? Vi uppmärksammar forskningen om säljägarna i Ajvide på Gotland där jägar- och fiskekulturen frodades för 5000 år sedan.</p> <p>De vägrade bli bönder och valde istället att fiska och jaga säl längs Skandinaviens kuster. I gotländska Ajvide finns de bäst bevarade resterna av den gropkeramiska kulturen, som för 5000 år sedan dominerade våra kuster och som inte ville beblanda sig särskilt mycket med jordbrukarna i inlandet. Tobias Svanelid uppmärksammar den aktuella forskning som nu försöker förstå sig på gropkeramikerna bättre och som bland det enorma skelettmaterialet ifrån Ajvide hittar tecken på enorma grisfester, igelkottsdyrkan och en envishet att hålla kvar vid sin egen livsstil i konkurrens med bönderna.</p><p>Dessutom svarar Dick Harrison på en lyssnarfråga om hur det kunde gå så snabbt när islam spreds över Europa och Asien under medeltiden.</p>",
+                    "id": "2JIxVl3WyaeXYH6VRi49C8",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ad2d7cf7404c17b2bd2dece17",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fd2d7cf7404c17b2bd2dece17",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dd2d7cf7404c17b2bd2dece17",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "446 – Bart Gets a Z",
-                    "release_date": "2022-11-28",
+                    "name": "Stenålderns säljägare kartläggs",
+                    "release_date": "2023-03-14",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:4N0govIwm1jIKL6M3Sp5Fs"
+                    "uri": "spotify:episode:2JIxVl3WyaeXYH6VRi49C8"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/6bdf6e6dc0dd47fcc26aebd07fca5a6b58796d0a",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF13, Homer the Whopper, the first episode of Season Twenty-One. They talk about superhero movies, better episodes, and sincerity. Get your copy of Robbie’s new book, THE OTHER Support the show on Patreon Listener Question of the Week: What’s your favorite Comic Book Guy quote?",
-                    "duration_ms": 4751469,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/57e22f139de2b3b0035d5c59f8f53a620c8948c7",
+                    "description": "Hur skapades Sveriges största propagandamålning från Stormaktstiden? Nytt forskningsprojekt kartlägger Riddarhusets blaffiga takmålning. Och så reder Dick Harrison ut svenska kolonialäventyr i Afrika. Riddarhusets tak pryds av konstverket Dygdernas rådslag, där 1600-talets Moder Svea sitter uppflugen på ett moln för att sprida budskapet om den nya supermakten Sverige. Konstnären David Kläcker Ehrenstrahls målning har kommit att bli sinnebilden för stormaktstidens svenska propaganda, men hur bilden kom till och hur den har förändrats undersökt nu i ett nytt forskningsprojekt. Med hjälp av infrarött och ultraviolett ljus försöker konstvetare nu penetrera konstverkets historia.Dessutom återser vi den arga historikern, bloggkollektivet som ville få in historiska perspektiv i samtidsdebatten, men som nu lägger ner. Varför?Och så reder Dick Harrison ut den smått nedtystade historien om Sveriges koloniala äventyr på afrikanska Guldkusten.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/2zCmjk3ze0sga405IA51BZ"
+                        "spotify": "https://open.spotify.com/episode/6RqBTuLHKZaNLuvjJEfzH4"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/2zCmjk3ze0sga405IA51BZ",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF13, Homer the Whopper, the first episode of Season Twenty-One. They talk about superhero movies, better episodes, and sincerity. Get your copy of Robbie’s new book, THE OTHER Support the show on Patreon Listener Question of the Week: What’s your favorite Comic Book Guy quote?",
-                    "id": "2zCmjk3ze0sga405IA51BZ",
+                    "href": "https://api.spotify.com/v1/episodes/6RqBTuLHKZaNLuvjJEfzH4",
+                    "html_description": "<p>Hur skapades Sveriges största propagandamålning från Stormaktstiden? Nytt forskningsprojekt kartlägger Riddarhusets blaffiga takmålning. Och så reder Dick Harrison ut svenska kolonialäventyr i Afrika.</p> <p>Riddarhusets tak pryds av konstverket Dygdernas rådslag, där 1600-talets Moder Svea sitter uppflugen på ett moln för att sprida budskapet om den nya supermakten Sverige. Konstnären David Kläcker Ehrenstrahls målning har kommit att bli sinnebilden för stormaktstidens svenska propaganda, men hur bilden kom till och hur den har förändrats undersökt nu i ett nytt forskningsprojekt. Med hjälp av infrarött och ultraviolett ljus försöker konstvetare nu penetrera konstverkets historia.</p><p>Dessutom återser vi den arga historikern, bloggkollektivet som ville få in historiska perspektiv i samtidsdebatten, men som nu lägger ner. Varför?</p><p>Och så reder Dick Harrison ut den smått nedtystade historien om Sveriges koloniala äventyr på afrikanska Guldkusten.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "6RqBTuLHKZaNLuvjJEfzH4",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a7684f26157d1efe988930052",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f7684f26157d1efe988930052",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d7684f26157d1efe988930052",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "445 – Homer the Whopper",
-                    "release_date": "2022-11-21",
+                    "name": "Stormaktstidens propagandabild kartläggs",
+                    "release_date": "2023-03-07",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:2zCmjk3ze0sga405IA51BZ"
+                    "uri": "spotify:episode:6RqBTuLHKZaNLuvjJEfzH4"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f381f9ececcea862f39fcfd708807aa7aa1c1455",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF12, Coming to Homerica, the final episode of Season Twenty. They talk about immigration, walls, and barley farming. Pre-Order The Other Support the show on the Patreon! Listener Question of the Week: What’s your favorite moment from Season Twenty?",
-                    "duration_ms": 5243613,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/40344321fb2ce57db4371a98fe546ab7ebd7c72c",
+                    "description": "De historiska trådarna mellan Sverige och Ukraina är många och starka, inte minst under vikingatid och under Karl XII:s fälttåg i öst. Vetenskapsradion Historia uppmärksammar vår gemensamma historia. Under vikingatid kryllade Kiev av svenskättade vikingar och på 1700-talet stred Karl XII för Ukrainas sak. Vetenskapsradion Historia uppmärksammar forskningsprojekten som nu vill rikta ljuset på Sverige och Ukrainas långa gemensamma historia som döljer sig i arkivens och museernas källare.Elin Fornander vid Historiska museet berättar om det nya initiativ som syftar till att lyfta fram de föremål i både svenska och ukrainska museer som kan berätta om kontakterna mellan länderna. Det handlar, menar hon, om ett nytt sätt att berätta historia och att låta var och en dra sina egna slutsatser av de många källor som finns.Arkeologen Charlotte Hedenstierna Jonsson berättar om det skandinavisk-slaviska samhälle som växte fram runt Kiev under vikingatiden och vad nya DNA-analyser kan berätta om den multietniska befolkning som gärna ville framstå som tuffa vikingar, oavsett vilket ursprung man hade.Och så berättar historikern Jan Mispelaere vid Riksarkivet om alla de dokument som avslöjar Karl XII:s och Stormakts-Sveriges djupa engagemang för ett fritt Ukraina. Förutom den första ukrainska konstitutionen finns i svenska arkiv unika dokument som berättar om den ukrainska nationens första stapplande steg.Programledare är Tobias Svanelid och programmet spelades in för publik på Historiska museet på årsdagen av Rysslands invasion av Ukraina.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/6gQCBJFhvMTZ6YEYhORGEV"
+                        "spotify": "https://open.spotify.com/episode/0cb9UNjnuesXZATgvZBftU"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/6gQCBJFhvMTZ6YEYhORGEV",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF12, Coming to Homerica, the final episode of Season Twenty. They talk about immigration, walls, and barley farming. Pre-Order The Other Support the show on the Patreon! Listener Question of the Week: What’s your favorite moment from Season Twenty?",
-                    "id": "6gQCBJFhvMTZ6YEYhORGEV",
+                    "href": "https://api.spotify.com/v1/episodes/0cb9UNjnuesXZATgvZBftU",
+                    "html_description": "<p>De historiska trådarna mellan Sverige och Ukraina är många och starka, inte minst under vikingatid och under Karl XII:s fälttåg i öst. Vetenskapsradion Historia uppmärksammar vår gemensamma historia.</p> <p>Under vikingatid kryllade Kiev av svenskättade vikingar och på 1700-talet stred Karl XII för Ukrainas sak. Vetenskapsradion Historia uppmärksammar forskningsprojekten som nu vill rikta ljuset på Sverige och Ukrainas långa gemensamma historia som döljer sig i arkivens och museernas källare.</p><p>Elin Fornander vid Historiska museet berättar om det nya initiativ som syftar till att lyfta fram de föremål i både svenska och ukrainska museer som kan berätta om kontakterna mellan länderna. Det handlar, menar hon, om ett nytt sätt att berätta historia och att låta var och en dra sina egna slutsatser av de många källor som finns.</p><p>Arkeologen Charlotte Hedenstierna Jonsson berättar om det skandinavisk-slaviska samhälle som växte fram runt Kiev under vikingatiden och vad nya DNA-analyser kan berätta om den multietniska befolkning som gärna ville framstå som tuffa vikingar, oavsett vilket ursprung man hade.</p><p>Och så berättar historikern Jan Mispelaere vid Riksarkivet om alla de dokument som avslöjar Karl XII:s och Stormakts-Sveriges djupa engagemang för ett fritt Ukraina. Förutom den första ukrainska konstitutionen finns i svenska arkiv unika dokument som berättar om den ukrainska nationens första stapplande steg.</p><p>Programledare är Tobias Svanelid och programmet spelades in för publik på Historiska museet på årsdagen av Rysslands invasion av Ukraina.</p>",
+                    "id": "0cb9UNjnuesXZATgvZBftU",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aac2e70e6b50b638f8c4d447b",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fac2e70e6b50b638f8c4d447b",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dac2e70e6b50b638f8c4d447b",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "444 – Coming to Homerica",
-                    "release_date": "2022-11-14",
+                    "name": "Ukrainas historia är vår",
+                    "release_date": "2023-02-28",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:6gQCBJFhvMTZ6YEYhORGEV"
+                    "uri": "spotify:episode:0cb9UNjnuesXZATgvZBftU"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/fb862043f884ea5f5549bbae1d82761a48b98c3c",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF09, Four Great Women and a Manicure, the twentieth episode of Season Twenty. They talk about themes in anthology, Jodie Foster, and Macbeth. Pre-Order The Other Support the show on Patreon Listener Question of the Week: What theme would you use for a Simpsons anthology episode?",
-                    "duration_ms": 5514327,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/78960c689287a453b6af25c4ca65fbe78e02fff0",
+                    "description": "Hur länge kan en gäst stanna hos dig innan du tröttnar? Nu har historiker undersökt gästfrihetens historia och avslöjar våra attityder gentemot främlingar, flyktingar och krigsfångar. Hur har vi tänkt kring gäster, flyktingar och andra som kommit på kortare eller längre besök i Sverige? I en aktuell bok undersöker historiker gästfrihetens historia, där svenskarna, redan sedan medeltiden verkat ha intagit en särställning.- Adam av Bremen skrev redan på 1000-talet att av alla folk kring Östersjön var svenskarna de mest gästfria, berättar historikern Wojtek Jezierski.Historikerna Olof Blomqvist och Sari Nauman studerar situationen med krigsflyktingar och krigsfångar som kom till Sverige under Stora nordiska kriget på 1700-talet, och som snabbt kom att bli undersåtarnas, snarare än kungens ansvar. Hur flyktingarna skulle hjälpas och vem som var i störst behov av hjälp var frågor som svenskarna då ställde sig för första gången.Dessutom svarar Dick Harrison om vilket som varit det senaste kriget som Storbritannien förlorat.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7jvNyEBCzTdbn1BBqvOPA1"
+                        "spotify": "https://open.spotify.com/episode/2xZE8R1aWDDeZUDGgHIsbC"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7jvNyEBCzTdbn1BBqvOPA1",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF09, Four Great Women and a Manicure, the twentieth episode of Season Twenty. They talk about themes in anthology, Jodie Foster, and Macbeth. Pre-Order The Other Support the show on Patreon Listener Question of the Week: What theme would you use for a Simpsons anthology episode?",
-                    "id": "7jvNyEBCzTdbn1BBqvOPA1",
+                    "href": "https://api.spotify.com/v1/episodes/2xZE8R1aWDDeZUDGgHIsbC",
+                    "html_description": "<p>Hur länge kan en gäst stanna hos dig innan du tröttnar? Nu har historiker undersökt gästfrihetens historia och avslöjar våra attityder gentemot främlingar, flyktingar och krigsfångar.</p> <p>Hur har vi tänkt kring gäster, flyktingar och andra som kommit på kortare eller längre besök i Sverige? I en aktuell <a href=\"https://link.springer.com/book/10.1007/978-3-030-98527-1\" rel=\"nofollow\">bok</a> undersöker historiker gästfrihetens historia, där svenskarna, redan sedan medeltiden verkat ha intagit en särställning.</p><p>- Adam av Bremen skrev redan på 1000-talet att av alla folk kring Östersjön var svenskarna de mest gästfria, berättar historikern Wojtek Jezierski.</p><p>Historikerna Olof Blomqvist och Sari Nauman studerar situationen med krigsflyktingar och krigsfångar som kom till Sverige under Stora nordiska kriget på 1700-talet, och som snabbt kom att bli undersåtarnas, snarare än kungens ansvar. Hur flyktingarna skulle hjälpas och vem som var i störst behov av hjälp var frågor som svenskarna då ställde sig för första gången.</p><p>Dessutom svarar Dick Harrison om vilket som varit det senaste kriget som Storbritannien förlorat.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "2xZE8R1aWDDeZUDGgHIsbC",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a1ff0f85f8b5886b801a602f6",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f1ff0f85f8b5886b801a602f6",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d1ff0f85f8b5886b801a602f6",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "443 – Four Great Women and a Manicure",
-                    "release_date": "2022-11-07",
+                    "name": "Gästfrihetens historia",
+                    "release_date": "2023-02-21",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7jvNyEBCzTdbn1BBqvOPA1"
+                    "uri": "spotify:episode:2xZE8R1aWDDeZUDGgHIsbC"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f948cd307edf9cfcccd04a5362d062361afba734",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF10, Waverly Hills, 9-0-2-1-D’oh, the nineteenth episode of Season Twenty. They talk about apartments, popularity, and Alaska Nebraska. Pre-Order The Other Support the show on Patreon Listener Question of the Week: What’s your favorite fictional setting that isn’t Springfield?",
-                    "duration_ms": 4771412,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/a5d2de2735e32c2029cb0bf3b3c264e15290f229",
+                    "description": "Hur får man ner Sveriges 15 000 år långa historia på 10 timmar? Vi träffar producenterna bakom kommande SVT-satsningen Historien om Sverige. Och så analyserar vi Sveriges största fiasko på slagfältet. Det är televisionens genom tidernas största satsning på en historisk dokumentärserie. I höst får SVT:s Historien om Sverige premiär men redan nu tar Vetenskapsradion Historia pulsen på mastodontprojektet som försöker sammanfatta 15 000 år på 10 timmar. Vi följer med när Axel von Fersen klubbas ihjäl av en ilsken folkhop och pratar med producenter, regissör och maskörer om utmaningarna att återskapa historien.Dessutom reder Dick Harrison ut hur Sveriges blodigaste fiasko på slagfältet, slaget vid Kirkholm 1605, kunde hända, och varför vi så ogärna vill tala om katastrofen fyrahundra år senare.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/5GfNpo7CSz0gMkEgfosWkj"
+                        "spotify": "https://open.spotify.com/episode/67XbBVD2TkKVqOFw6vhJYY"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/5GfNpo7CSz0gMkEgfosWkj",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF10, Waverly Hills, 9-0-2-1-D’oh, the nineteenth episode of Season Twenty. They talk about apartments, popularity, and Alaska Nebraska. Pre-Order The Other Support the show on Patreon Listener Question of the Week: What’s your favorite fictional setting that isn’t Springfield?",
-                    "id": "5GfNpo7CSz0gMkEgfosWkj",
+                    "href": "https://api.spotify.com/v1/episodes/67XbBVD2TkKVqOFw6vhJYY",
+                    "html_description": "<p>Hur får man ner Sveriges 15 000 år långa historia på 10 timmar? Vi träffar producenterna bakom kommande SVT-satsningen Historien om Sverige. Och så analyserar vi Sveriges största fiasko på slagfältet.</p> <p>Det är televisionens genom tidernas största satsning på en historisk dokumentärserie. I höst får SVT:s Historien om Sverige premiär men redan nu tar Vetenskapsradion Historia pulsen på mastodontprojektet som försöker sammanfatta 15 000 år på 10 timmar. Vi följer med när Axel von Fersen klubbas ihjäl av en ilsken folkhop och pratar med producenter, regissör och maskörer om utmaningarna att återskapa historien.</p><p>Dessutom reder Dick Harrison ut hur Sveriges blodigaste fiasko på slagfältet, slaget vid Kirkholm 1605, kunde hända, och varför vi så ogärna vill tala om katastrofen fyrahundra år senare.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "67XbBVD2TkKVqOFw6vhJYY",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a8a231a52fc7a3af4b5b9d9c9",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f8a231a52fc7a3af4b5b9d9c9",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d8a231a52fc7a3af4b5b9d9c9",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "442 – Waverly Hills, 9-0-2-1-D’oh",
-                    "release_date": "2022-10-31",
+                    "name": "SVT storsatsar på Historien om Sverige",
+                    "release_date": "2023-02-14",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:5GfNpo7CSz0gMkEgfosWkj"
+                    "uri": "spotify:episode:67XbBVD2TkKVqOFw6vhJYY"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b909b456bfa3e042ff5589f44318b137f9936211",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF08, Father Knows Worst, the eighteenth episode of Season Twenty. They talk about lucky rolls, the realism curve, and water heaters. Support the show on Patreon! Listener Question of the Week: What’s your favorite movie about parenting?",
-                    "duration_ms": 5525889,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/c6bbe462b25aeabbce31718205d5521b64d810ba",
+                    "description": "Hur gick det till när de gamla asagudarna byttes mot Jesus? Ny forskning visar att processen kunde gå våldsamt till och att många hedniska tankar levde kvar långt in i vår egen tid. Med mutor, hot och våld tvingade kyrkan och missionärerna Nordens hedningar att lämna sina gamla gudar. Tor, Oden och Freja byttes mot Jesus Kristus under en process som ibland var allt annat än fredlig. Religionshistorikern Olof Sundqvist har undersökt hur den här revolutionerande förändringen i Norden gick till och vad som levt kvar av hedniska tankar och trosföreställningar också efter att kyrkorna började byggas.Dessutom om mossliken som nu inventerats och undersökts i en ny studie. Arkeologen Sophie Bergerbrant berättar om den mångtusenåriga traditionen att sänka ner människokroppar i dimmiga mossar och kärr och hur den här seden levt kvar långt in i modern tid.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/03OwMkCzlkckDiYpqMfab2"
+                        "spotify": "https://open.spotify.com/episode/0Uhlkv492kg7IRKZkU0Web"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/03OwMkCzlkckDiYpqMfab2",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF08, Father Knows Worst, the eighteenth episode of Season Twenty. They talk about lucky rolls, the realism curve, and water heaters. Support the show on Patreon! Listener Question of the Week: What’s your favorite movie about parenting?",
-                    "id": "03OwMkCzlkckDiYpqMfab2",
+                    "href": "https://api.spotify.com/v1/episodes/0Uhlkv492kg7IRKZkU0Web",
+                    "html_description": "<p>Hur gick det till när de gamla asagudarna byttes mot Jesus? Ny forskning visar att processen kunde gå våldsamt till och att många hedniska tankar levde kvar långt in i vår egen tid.</p> <p>Med mutor, hot och våld tvingade kyrkan och missionärerna Nordens hedningar att lämna sina gamla gudar. Tor, Oden och Freja byttes mot Jesus Kristus under en process som ibland var allt annat än fredlig. Religionshistorikern Olof Sundqvist har undersökt hur den här revolutionerande förändringen i Norden gick till och vad som levt kvar av hedniska tankar och trosföreställningar också efter att kyrkorna började byggas.</p><p>Dessutom om mossliken som nu inventerats och undersökts i en ny studie. Arkeologen Sophie Bergerbrant berättar om den mångtusenåriga traditionen att sänka ner människokroppar i dimmiga mossar och kärr och hur den här seden levt kvar långt in i modern tid.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "0Uhlkv492kg7IRKZkU0Web",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a98a20e10fbae0fb264729113",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f98a20e10fbae0fb264729113",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d98a20e10fbae0fb264729113",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "441 – Father Knows Worst",
-                    "release_date": "2022-10-24",
+                    "name": "När Oden byttes mot Jesus",
+                    "release_date": "2023-02-07",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:03OwMkCzlkckDiYpqMfab2"
+                    "uri": "spotify:episode:0Uhlkv492kg7IRKZkU0Web"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/0fd3ee00584c2c5762876ffeb1a2613567a4ac8f",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF07, The Good, the Sad, and the Drugly, the seventeenth episode of Season Twenty. They talk about Bart’s girlfriends, drugs, and friendships. Support the show on the Patreon! Listener Question of the Week: What’s your favorite Anne Hathaway movie?",
-                    "duration_ms": 4712837,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/02ebea9ddc9a9e6099eb0281bcce148e5bec85cf",
+                    "description": "Flickor förväntades ta mest ansvar för oönskade graviditeter och sexuellt överförbara sjukdomar också under den sexuella revolutionen. Trots nya tankar levde gamla normer kvar visar ny forskning. Den sexuella revolutionen på 70-talet innebar en ny syn på sex och samliv, men gamla tankar levde kvar. Historikern Anna-Karin Larsson har studerat debatterna i dåtidens medicinska tidskrifter och visar hur flickor fortfarande förväntades ta ansvar inte bara för sin egen sexualitet men också för pojkarnas.Vi undersöker också hur minnet av Mahatma Gandhi lever kvar i Indien, 75 år efter mordet på landsfadern. Sveriges Radios Sydasienkorrespondent Naila Saleem menar att Gandhi inte hade känt igen sig i dagens Indien.Och så svarar Dick Harrison på en lyssnarfråga om hur det gick till när den långa gränsen mellan Sverige och Norge skulle dras på 1700-talet.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/4269D6LLvYZZLWu2qLS2kg"
+                        "spotify": "https://open.spotify.com/episode/5GU0RuFEvJVlFGLxRoVKSz"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/4269D6LLvYZZLWu2qLS2kg",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF07, The Good, the Sad, and the Drugly, the seventeenth episode of Season Twenty. They talk about Bart’s girlfriends, drugs, and friendships. Support the show on the Patreon! Listener Question of the Week: What’s your favorite Anne Hathaway movie?",
-                    "id": "4269D6LLvYZZLWu2qLS2kg",
+                    "href": "https://api.spotify.com/v1/episodes/5GU0RuFEvJVlFGLxRoVKSz",
+                    "html_description": "<p>Flickor förväntades ta mest ansvar för oönskade graviditeter och sexuellt överförbara sjukdomar också under den sexuella revolutionen. Trots nya tankar levde gamla normer kvar visar ny forskning.</p> <p>Den sexuella revolutionen på 70-talet innebar en ny syn på sex och samliv, men gamla tankar levde kvar. Historikern Anna-Karin Larsson har studerat debatterna i dåtidens medicinska tidskrifter och visar hur flickor fortfarande förväntades ta ansvar inte bara för sin egen sexualitet men också för pojkarnas.</p><p>Vi undersöker också hur minnet av Mahatma Gandhi lever kvar i Indien, 75 år efter mordet på landsfadern. Sveriges Radios Sydasienkorrespondent Naila Saleem menar att Gandhi inte hade känt igen sig i dagens Indien.</p><p>Och så svarar Dick Harrison på en lyssnarfråga om hur det gick till när den långa gränsen mellan Sverige och Norge skulle dras på 1700-talet.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "5GU0RuFEvJVlFGLxRoVKSz",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8af7e700ae86451ae6c667541b",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1ff7e700ae86451ae6c667541b",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68df7e700ae86451ae6c667541b",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "440 – The Good, the Sad, and the Drugly",
-                    "release_date": "2022-10-17",
+                    "name": "Tjejer tog mest ansvar för sex",
+                    "release_date": "2023-01-31",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:4269D6LLvYZZLWu2qLS2kg"
+                    "uri": "spotify:episode:5GU0RuFEvJVlFGLxRoVKSz"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/61ad3201ab1ce5d24364ec5142ef6c38d0354f80",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF06, Eeny Teeny Maya Moe, the sixteenth episode of Season Twenty. They talk about Maya, easy jokes, and giant Kearney babies beating up Homer. Support the show on Patreon! Listener Question of the Week: What’s your favorite movie with a baby in it?",
-                    "duration_ms": 5738518,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/50e659c576893b88f64b1ae9127c8b0e43101264",
+                    "description": "Inte som lamm till slakt. Kenneth Hermeles nya bok om judiskt motstånd under Förintelsen ger en helt ny bild av hur judar i Europa gjorde kraftigt motstånd mot sina nazistiska bödlar. Judarna gjorde inte nämnvärt motstånd mot sina nazistiska bödlar under Förintelsen, utan leddes ”som lamm till slakt” har det hetat. Nu visar författaren Kenneth Hermele i en aktuell bok att så var långt ifrån fallet och tillsammans med Tobias Svanelid diskuterar han såväl våldsamma partisanaktioner, dödliga danserskor i förintelselägren och kulsprutor i synagogan, som judisk smuggling, teateruppsättningar och arkivarbete som tillsammans ger bilden av ett kraftfullt judiskt motstånd.Dessutom reder Dick Harrison ut hur rädda folk var inför millennieskiftet år 1000.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/3Stp9u0dQP703fTUEYnfSX"
+                        "spotify": "https://open.spotify.com/episode/6OWCSj6Axvo1HaWl60yuYS"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/3Stp9u0dQP703fTUEYnfSX",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF06, Eeny Teeny Maya Moe, the sixteenth episode of Season Twenty. They talk about Maya, easy jokes, and giant Kearney babies beating up Homer. Support the show on Patreon! Listener Question of the Week: What’s your favorite movie with a baby in it?",
-                    "id": "3Stp9u0dQP703fTUEYnfSX",
+                    "href": "https://api.spotify.com/v1/episodes/6OWCSj6Axvo1HaWl60yuYS",
+                    "html_description": "<p>Inte som lamm till slakt. Kenneth Hermeles nya bok om judiskt motstånd under Förintelsen ger en helt ny bild av hur judar i Europa gjorde kraftigt motstånd mot sina nazistiska bödlar.</p> <p>Judarna gjorde inte nämnvärt motstånd mot sina nazistiska bödlar under Förintelsen, utan leddes ”som lamm till slakt” har det hetat. Nu visar författaren Kenneth Hermele i en aktuell bok att så var långt ifrån fallet och tillsammans med Tobias Svanelid diskuterar han såväl våldsamma partisanaktioner, dödliga danserskor i förintelselägren och kulsprutor i synagogan, som judisk smuggling, teateruppsättningar och arkivarbete som tillsammans ger bilden av ett kraftfullt judiskt motstånd.</p><p>Dessutom reder Dick Harrison ut hur rädda folk var inför millennieskiftet år 1000.</p>",
+                    "id": "6OWCSj6Axvo1HaWl60yuYS",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a4f8d504935bba46193b5a698",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f4f8d504935bba46193b5a698",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d4f8d504935bba46193b5a698",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "439 – Eeny Teeny Maya Moe",
-                    "release_date": "2022-10-10",
+                    "name": "Judiskt motstånd under Förintelsen",
+                    "release_date": "2023-01-24",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:3Stp9u0dQP703fTUEYnfSX"
+                    "uri": "spotify:episode:6OWCSj6Axvo1HaWl60yuYS"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/6aeae772776de9fdb5ad9d5dfa17fe9c905b2a49",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF05, Wedding for Disaster, the fifteenth episode of Season Twenty. They talk about weddings, kidnappings, and Sideshow Bob bait and switches. Support the show on Patreon! Listener Question of the Week: What’s your favorite movie featuring a wedding?",
-                    "duration_ms": 5105229,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b323efde89c89f7c697edc47b94afb15e8aa7035",
+                    "description": "Vetenskapsradion Historia fortsätter resan i etruskernas fotspår, i jakt på det mytomspunna folkets liv för 2 500 år sedan, bland mäktiga tempelruiner och praktfulla gravkammare. Följ med Tobias Svanelid och arkeologen Richard Holmgren i etruskernas fotspår – när de fortsätter att söka efter spåren efter såväl de levande som de döda etruskerna. I San Giovenales 2 500-åriga ruiner testar man dryckesspel och i Tarquinias tempelruiner diskuteras augurernas och andra etruskiska siares förmågor att förutsäga framtiden. Dessutom besöker man de magnifika gravfälten i Monterozzi – Italiens Konungarnas dal, testar att måla svartfigurig keramik på etruskiskt vis, och reser till Banditaccianekropolen, den antika medelhavsvärldens största gravplats med praktfulla gravar som skildrar livet på 500-talet före Kristus.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7ISxmLZ2flOUxO892dSawz"
+                        "spotify": "https://open.spotify.com/episode/1MSkmRUjGpcOC2Q4UrBHsx"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7ISxmLZ2flOUxO892dSawz",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF05, Wedding for Disaster, the fifteenth episode of Season Twenty. They talk about weddings, kidnappings, and Sideshow Bob bait and switches. Support the show on Patreon! Listener Question of the Week: What’s your favorite movie featuring a wedding?",
-                    "id": "7ISxmLZ2flOUxO892dSawz",
+                    "href": "https://api.spotify.com/v1/episodes/1MSkmRUjGpcOC2Q4UrBHsx",
+                    "html_description": "<p>Vetenskapsradion Historia fortsätter resan i etruskernas fotspår, i jakt på det mytomspunna folkets liv för 2 500 år sedan, bland mäktiga tempelruiner och praktfulla gravkammare.</p> <p>Följ med Tobias Svanelid och arkeologen Richard Holmgren i etruskernas fotspår – när de fortsätter att söka efter spåren efter såväl de levande som de döda etruskerna. I San Giovenales 2 500-åriga ruiner testar man dryckesspel och i Tarquinias tempelruiner diskuteras augurernas och andra etruskiska siares förmågor att förutsäga framtiden. Dessutom besöker man de magnifika gravfälten i Monterozzi – Italiens Konungarnas dal, testar att måla svartfigurig keramik på etruskiskt vis, och reser till Banditaccianekropolen, den antika medelhavsvärldens största gravplats med praktfulla gravar som skildrar livet på 500-talet före Kristus.</p>",
+                    "id": "1MSkmRUjGpcOC2Q4UrBHsx",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a537376c5d636741e3113653b",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f537376c5d636741e3113653b",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d537376c5d636741e3113653b",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "438 – Wedding for Disaster",
-                    "release_date": "2022-10-03",
+                    "name": "I etruskernas fotspår",
+                    "release_date": "2023-01-17",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7ISxmLZ2flOUxO892dSawz"
+                    "uri": "spotify:episode:1MSkmRUjGpcOC2Q4UrBHsx"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/fa6401ca737883068a9872d140addae9fbde6486",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF11, In the Name of the Grandfather, the fourteenth episode of Season Twenty. They talk about Ireland, leprechauns, and literally no story. Support the show on Patreon! Listener Question of the Week: Who’s your favorite Irish actor and what’s your favorite thing they’ve been in?",
-                    "duration_ms": 3965640,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/06cffa10385089272216a19db60410bf07123343",
+                    "description": "Följ med Tobias Svanelid och arkeologen Richard Holmgren på en resa i etruskernas värld. Vad var det för folk som föregick romarna som Italiens härskare och varifrån kom de? De dominerade de italienska halvön hundratals år innan romarna steg upp på scenen, och de utvecklade en kultur som än idag fascinerar och förbryllar. Vetenskapsradion Historias Tobias Svanelid reser med arkeologen Richard Holmgren till etruskernas värld för att ta reda på vilka detta mytomspunna folk egentligen var. I gravkammare, djupa raviner och bland etruskiska ruiner och lämningar diskuteras bland annat frågan om etruskernas mystiska ursprung och språk. Var kom de egentligen ifrån? Och så diskuteras en teori till varför etruskerna kom att få en så dominant position runt Medelhavet för 2 500 år sedan.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/1a4XIlwN3HHfEKzbPK9PB1"
+                        "spotify": "https://open.spotify.com/episode/3qnAJYd3yhwNpHQ9mJ23xS"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/1a4XIlwN3HHfEKzbPK9PB1",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF11, In the Name of the Grandfather, the fourteenth episode of Season Twenty. They talk about Ireland, leprechauns, and literally no story. Support the show on Patreon! Listener Question of the Week: Who’s your favorite Irish actor and what’s your favorite thing they’ve been in?",
-                    "id": "1a4XIlwN3HHfEKzbPK9PB1",
+                    "href": "https://api.spotify.com/v1/episodes/3qnAJYd3yhwNpHQ9mJ23xS",
+                    "html_description": "<p>Följ med Tobias Svanelid och arkeologen Richard Holmgren på en resa i etruskernas värld. Vad var det för folk som föregick romarna som Italiens härskare och varifrån kom de?</p> <p>De dominerade de italienska halvön hundratals år innan romarna steg upp på scenen, och de utvecklade en kultur som än idag fascinerar och förbryllar. Vetenskapsradion Historias Tobias Svanelid reser med arkeologen Richard Holmgren till etruskernas värld för att ta reda på vilka detta mytomspunna folk egentligen var. I gravkammare, djupa raviner och bland etruskiska ruiner och lämningar diskuteras bland annat frågan om etruskernas mystiska ursprung och språk. Var kom de egentligen ifrån? Och så diskuteras en teori till varför etruskerna kom att få en så dominant position runt Medelhavet för 2 500 år sedan.</p>",
+                    "id": "3qnAJYd3yhwNpHQ9mJ23xS",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a7118bd77c986982b079ae3cb",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f7118bd77c986982b079ae3cb",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d7118bd77c986982b079ae3cb",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "437 – In the Name of the Grandfather",
-                    "release_date": "2022-09-26",
+                    "name": "De mytomspunna etruskerna",
+                    "release_date": "2023-01-10",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:1a4XIlwN3HHfEKzbPK9PB1"
+                    "uri": "spotify:episode:3qnAJYd3yhwNpHQ9mJ23xS"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/3a4d3cf9041b422d5f8f7ab9f076acf1388bddc6",
-                    "description": "Tonight, Matt and Robbie are joined by Andrew Bloom to discuss Episode LABF04, Gone Maggie Gone, the thirteenth episode of Season Twenty. They talk about magic gem babies, The Da Vinci Code, and Robbie losing his mind. Support the show on Patreon! Listener Question of the Week – What’s your favorite thriller?",
-                    "duration_ms": 7193938,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/df961768a0d0a7c1256f12d406c067385faa6341",
+                    "description": "Demokratiska städer, buffeltokiga präriefolk och mänsklig uppfinningsrikedom och lekfullhet står i fokus när forntidshistorien nu skrivs om. Vi träffar författaren till omdebatterade Början på allt. Vår bild av forntiden och människans förhistoria formades för hundratals år sedan, men är dags att slå sönder. I boken Början på allt vill arkeologen David Wengrow och antropologen David Graeber ge en myllrande bild av alla de olika sätt som forntidsmänniskan format sina städer och tidiga civilisationer på. Glöm föreställningarna om en ursprunglig utopisk harmoni eller ett allas krig mot alla – forntiden kunde vara allt detta men mycket, mycket mer.Dessutom listar Urban Björstadius det gångna årets tio viktigaste arkeologiska upptäckter och så träffar vi egyptologen Zahi Hawass som suttit som en spindel i nätet i all fornegyptisk forskning de senaste femtio åren och nu är engagerad i utgrävningarna av den bländande staden Aten.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/3jNBIR7m6YeF2iMqL0jlON"
+                        "spotify": "https://open.spotify.com/episode/52SjIso8es7SvxytK99pJn"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/3jNBIR7m6YeF2iMqL0jlON",
-                    "html_description": "Tonight, Matt and Robbie are joined by Andrew Bloom to discuss Episode LABF04, Gone Maggie Gone, the thirteenth episode of Season Twenty. They talk about magic gem babies, The Da Vinci Code, and Robbie losing his mind. Support the show on Patreon! Listener Question of the Week – What’s your favorite thriller?",
-                    "id": "3jNBIR7m6YeF2iMqL0jlON",
+                    "href": "https://api.spotify.com/v1/episodes/52SjIso8es7SvxytK99pJn",
+                    "html_description": "<p>Demokratiska städer, buffeltokiga präriefolk och mänsklig uppfinningsrikedom och lekfullhet står i fokus när forntidshistorien nu skrivs om. Vi träffar författaren till omdebatterade Början på allt.</p> <p>Vår bild av forntiden och människans förhistoria formades för hundratals år sedan, men är dags att slå sönder. I boken Början på allt vill arkeologen David Wengrow och antropologen David Graeber ge en myllrande bild av alla de olika sätt som forntidsmänniskan format sina städer och tidiga civilisationer på. Glöm föreställningarna om en ursprunglig utopisk harmoni eller ett allas krig mot alla – forntiden kunde vara allt detta men mycket, mycket mer.</p><p>Dessutom listar Urban Björstadius det gångna årets tio viktigaste arkeologiska upptäckter och så träffar vi egyptologen Zahi Hawass som suttit som en spindel i nätet i all fornegyptisk forskning de senaste femtio åren och nu är engagerad i utgrävningarna av den bländande staden Aten.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "52SjIso8es7SvxytK99pJn",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ac8ebfe77c168c59fa5a991e6",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fc8ebfe77c168c59fa5a991e6",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dc8ebfe77c168c59fa5a991e6",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "436 – Gone Maggie Gone (w Andrew Bloom)",
-                    "release_date": "2022-09-19",
+                    "name": "Forntidens historia skrivs om",
+                    "release_date": "2023-01-03",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:3jNBIR7m6YeF2iMqL0jlON"
+                    "uri": "spotify:episode:52SjIso8es7SvxytK99pJn"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/0db8819730dc2a42256d9cbbfb3ff2f0d883cee0",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF03, No Loan Again, Naturally, the twelfth episode of Season Twenty. They talk about loans, mortgages, and things that should just not be Simpsons episodes. Support the show on Patreon! Listener Question of the Week: What’s your favorite Flanders quote?",
-                    "duration_ms": 4834689,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b0a537ba043486fb098e88cd76d7be6dc823fca0",
+                    "description": "Vad minns du av historieåret 2022? Följ med Tobias Svanelid till årets jubileer och mest spännande forskning! Historiskt storkrig i Europa, historiskt höga elpriser och en historiskt skenande inflation. År 2022 har varit ett historiskt år, och Vetenskapsradion Historias Tobias Svanelid guidar dig runt bland de viktigaste historiska händelserna, från Vasaloppsjubileum till återskapade historiska spritsorter.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/2Fvyyerd234Yn8xUL9I3sQ"
+                        "spotify": "https://open.spotify.com/episode/4hK61wlkooPyRcS9TB2sr5"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/2Fvyyerd234Yn8xUL9I3sQ",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF03, No Loan Again, Naturally, the twelfth episode of Season Twenty. They talk about loans, mortgages, and things that should just not be Simpsons episodes. Support the show on Patreon! Listener Question of the Week: What’s your favorite Flanders quote?",
-                    "id": "2Fvyyerd234Yn8xUL9I3sQ",
+                    "href": "https://api.spotify.com/v1/episodes/4hK61wlkooPyRcS9TB2sr5",
+                    "html_description": "<p>Vad minns du av historieåret 2022? Följ med Tobias Svanelid till årets jubileer och mest spännande forskning!</p> <p>Historiskt storkrig i Europa, historiskt höga elpriser och en historiskt skenande inflation. År 2022 har varit ett historiskt år, och Vetenskapsradion Historias Tobias Svanelid guidar dig runt bland de viktigaste historiska händelserna, från Vasaloppsjubileum till återskapade historiska spritsorter.</p>",
+                    "id": "4hK61wlkooPyRcS9TB2sr5",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8af15ccf7523348d3ec743b0aa",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1ff15ccf7523348d3ec743b0aa",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68df15ccf7523348d3ec743b0aa",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "435 – No Loan Again, Naturally",
-                    "release_date": "2022-09-12",
+                    "name": "Historieåret 2022 avrundas",
+                    "release_date": "2022-12-27",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:2Fvyyerd234Yn8xUL9I3sQ"
+                    "uri": "spotify:episode:4hK61wlkooPyRcS9TB2sr5"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/3d8e7235df0748ab0fb79df8226dcdd40b942d91",
-                    "description": "Tonight, Matt and Robbie discuss Episode LABF02, How the Test Was Won, the eleventh episode of Season Twenty. They talk about standardized testing, Ralph’s powers, and insurance. Support the show on Patreon! Listener Question of the Week: What is your favorite sitcom that isn’t The Simpsons?",
-                    "duration_ms": 5042440,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/3caf8ce68782ff318aca069b574e9c3b14934641",
+                    "description": "Följ med Tobias Svanelid till Rhodos där spåren efter en av världshistoriens blodigaste belägringar fortfarande finns kvar. Hör om riddarnas sista strid, där johanniterorden försvarade sig mot turkar. För femhundra år sedan utspelade sig en av världshistoriens blodigaste och mest ikoniska belägringar. Uppemot 70 000 turkiska soldater stod mot 700 korsriddare på den grekiska ön Rhodos i vad som vissa menat var riddarnas sista strid. Tobias Svanelid reser till Rhodos för att se de mäktiga befästningarna och diskuterar belägringen med historikern Dick Harrison och vad striden kom att leda till för såväl johanniterorden som för turkarna.Dessutom träffar vi historikern som försöker förklara varför det känns så skönt när svenska skidlöpare vinner mot norrmän i OS.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/4EcP2j1JsLrMKA4Rb0w2Ei"
+                        "spotify": "https://open.spotify.com/episode/5emGcpaVVCSzPiTtmak3Md"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/4EcP2j1JsLrMKA4Rb0w2Ei",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode LABF02, How the Test Was Won, the eleventh episode of Season Twenty. They talk about standardized testing, Ralph’s powers, and insurance. Support the show on Patreon! Listener Question of the Week: What is your favorite sitcom that isn’t The Simpsons?",
-                    "id": "4EcP2j1JsLrMKA4Rb0w2Ei",
+                    "href": "https://api.spotify.com/v1/episodes/5emGcpaVVCSzPiTtmak3Md",
+                    "html_description": "<p>Följ med Tobias Svanelid till Rhodos där spåren efter en av världshistoriens blodigaste belägringar fortfarande finns kvar. Hör om riddarnas sista strid, där johanniterorden försvarade sig mot turkar.</p> <p>För femhundra år sedan utspelade sig en av världshistoriens blodigaste och mest ikoniska belägringar. Uppemot 70 000 turkiska soldater stod mot 700 korsriddare på den grekiska ön Rhodos i vad som vissa menat var riddarnas sista strid. Tobias Svanelid reser till Rhodos för att se de mäktiga befästningarna och diskuterar belägringen med historikern Dick Harrison och vad striden kom att leda till för såväl johanniterorden som för turkarna.</p><p>Dessutom träffar vi historikern som försöker förklara varför det känns så skönt när svenska skidlöpare vinner mot norrmän i OS.</p>",
+                    "id": "5emGcpaVVCSzPiTtmak3Md",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a75cbeeb1e70c7f821a28b2a4",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f75cbeeb1e70c7f821a28b2a4",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d75cbeeb1e70c7f821a28b2a4",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "434 – How the Test Was Won",
-                    "release_date": "2022-09-05",
+                    "name": "Belägringen av Rhodos 1522",
+                    "release_date": "2022-12-20",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:4EcP2j1JsLrMKA4Rb0w2Ei"
+                    "uri": "spotify:episode:5emGcpaVVCSzPiTtmak3Md"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d203bbe753262cab04ae82d44452a595a8b2b7da",
-                    "description": "Tonight, Matt and Robbie are joined by Bryan Green to discuss Episode LABF01, Take My Life, Please, tenth episode of Season Twenty. They talk about magic pasta sauce, magical realism, and flashbacks. Support the show on Patreon! Listener Question of the Week: What’s your favorite quote from a flashback?",
-                    "duration_ms": 6517465,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d1ce0826dbad511e66f2eedc56d715278009ea48",
+                    "description": "Glimrande hovliv, smarriga kolbullar, kloka korpar och fjälliga sjömänniskor samsas i Vetenskapsradion Historias julklappsboktips! Och så testar vi brädspelet i Jane Austens herrgårds-England! Missa inte Vetenskapsradion Historias julklappstips där Kristina Ekero Eriksson, Urban Björstadius och Tobias Svanelid tipsar om böcker om glimrande hovliv och kungligheter, om kolning, saffran, korpar och mycket, mycket annat. Och så testar Spelpanelen att navigera i Englands Downton Abbey-miljö i spelet Obsession och att överleva Första världskriget i The Grizzled.Böckerna och spelen som nämnts i programmet:Sagan om Saffran av Gunnel CarlssonKarl XV av Thorsten SandbergFrån Savolaxbrigden till Särskilda skyddsgruppen av Fredrik Eriksson, Lars Ericson Wolke och Gunnar ÅseliusAnfallskrigens argument av Ove BringTill eftervärlden av Marianne Molander BeyerDödens idéhistoria av Karin Dirke, Andreas Hellerstedt och Martin Wiklund (red)Mumier av Sofia HäggmanDe utomordentliga av Maja BondestamHovet av Björn AskerKolning av Gunnar NygrenKorpen av Bengt-Erik Engholm och Lina BlixtEuropas mödrar av Karin BojsJärnålderns symboler och dolda budskap av Kent AnderssonObsession av Dan HallagenThe Grizzled av Fabien Riffaud och Juan Rodriguez",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/146yb2i6DtTp9cEqwHoDje"
+                        "spotify": "https://open.spotify.com/episode/2xC5qxAqcxqNQpd1geIn7H"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/146yb2i6DtTp9cEqwHoDje",
-                    "html_description": "Tonight, Matt and Robbie are joined by Bryan Green to discuss Episode LABF01, Take My Life, Please, tenth episode of Season Twenty. They talk about magic pasta sauce, magical realism, and flashbacks. Support the show on Patreon! Listener Question of the Week: What’s your favorite quote from a flashback?",
-                    "id": "146yb2i6DtTp9cEqwHoDje",
+                    "href": "https://api.spotify.com/v1/episodes/2xC5qxAqcxqNQpd1geIn7H",
+                    "html_description": "<p>Glimrande hovliv, smarriga kolbullar, kloka korpar och fjälliga sjömänniskor samsas i Vetenskapsradion Historias julklappsboktips! Och så testar vi brädspelet i Jane Austens herrgårds-England!</p> <p>Missa inte Vetenskapsradion Historias julklappstips där Kristina Ekero Eriksson, Urban Björstadius och Tobias Svanelid tipsar om böcker om glimrande hovliv och kungligheter, om kolning, saffran, korpar och mycket, mycket annat. Och så testar Spelpanelen att navigera i Englands Downton Abbey-miljö i spelet Obsession och att överleva Första världskriget i The Grizzled.</p><p>Böckerna och spelen som nämnts i programmet:</p><p>Sagan om Saffran av Gunnel Carlsson</p><p>Karl XV av Thorsten Sandberg</p><p>Från Savolaxbrigden till Särskilda skyddsgruppen av Fredrik Eriksson, Lars Ericson Wolke och Gunnar Åselius</p><p>Anfallskrigens argument av Ove Bring</p><p>Till eftervärlden av Marianne Molander Beyer</p><p>Dödens idéhistoria av Karin Dirke, Andreas Hellerstedt och Martin Wiklund (red)</p><p>Mumier av Sofia Häggman</p><p>De utomordentliga av Maja Bondestam</p><p>Hovet av Björn Asker</p><p>Kolning av Gunnar Nygren</p><p>Korpen av Bengt-Erik Engholm och Lina Blixt</p><p>Europas mödrar av Karin Bojs</p><p>Järnålderns symboler och dolda budskap av Kent Andersson</p><p>Obsession av Dan Hallagen</p><p>The Grizzled av Fabien Riffaud och Juan Rodriguez</p>",
+                    "id": "2xC5qxAqcxqNQpd1geIn7H",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a0644c9896f8466a39e90fc17",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f0644c9896f8466a39e90fc17",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d0644c9896f8466a39e90fc17",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "433 – Take My Life, Please (w Bryan Green)",
-                    "release_date": "2022-08-29",
+                    "name": "Hovliv och kolbullar",
+                    "release_date": "2022-12-13",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:146yb2i6DtTp9cEqwHoDje"
+                    "uri": "spotify:episode:2xC5qxAqcxqNQpd1geIn7H"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d7d299ee531398f86084337bcaa4d4774bdf07f4",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF22, Lisa the Drama Queen, the ninth episode of Season Twenty. They talk about fantasy worlds, zero jokes, and John Grisham. Support the show on Patreon! Listener Question of the Week: What’s your favorite quote from the bullies?",
-                    "duration_ms": 4894414,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/55c6902d9659931a9e9e25b0b9a20ceb59bf91af",
+                    "description": "För femtio år sedan landade Apollo 17 på månen, men nu är vi på väg dit igen. Hör om människans ständiga längtan efter månen och vad vi genom historien trott och tänkt om denna mystiska himlakropp. Det har gått femtio år sedan människan senast satte fötterna på månen men nu är vi så smått på väg dit igen. Tobias Svanelid samtalar med arkeologen och amatörastronomen Jonathan Lindström om vad månen betytt för oss människor genom historien och vad vi trott om denna den närmsta av våra himlakroppar. Var månfläckarna egentligen utspilld tjära? Kunde man starta kring när månen stod i nedan? Är det sant att vi blir mångalna?Och så berättar historikern Lisa Svanfeldt-Winter om sin forskning om 1800-talets vetenskapsdebatt om huruvida jorden var platt. Idag frodas dessa tankar på sociala medier, men redan i mitten av 1800-talet lanserade Samuel Rowbotham sina teorier om en platt jord.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/408FVh0BcpDWgoRZGFGnef"
+                        "spotify": "https://open.spotify.com/episode/11L6kL6k1bSmS61bToXL3g"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/408FVh0BcpDWgoRZGFGnef",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF22, Lisa the Drama Queen, the ninth episode of Season Twenty. They talk about fantasy worlds, zero jokes, and John Grisham. Support the show on Patreon! Listener Question of the Week: What’s your favorite quote from the bullies?",
-                    "id": "408FVh0BcpDWgoRZGFGnef",
+                    "href": "https://api.spotify.com/v1/episodes/11L6kL6k1bSmS61bToXL3g",
+                    "html_description": "<p>För femtio år sedan landade Apollo 17 på månen, men nu är vi på väg dit igen. Hör om människans ständiga längtan efter månen och vad vi genom historien trott och tänkt om denna mystiska himlakropp.</p> <p>Det har gått femtio år sedan människan senast satte fötterna på månen men nu är vi så smått på väg dit igen. Tobias Svanelid samtalar med arkeologen och amatörastronomen Jonathan Lindström om vad månen betytt för oss människor genom historien och vad vi trott om denna den närmsta av våra himlakroppar. Var månfläckarna egentligen utspilld tjära? Kunde man starta kring när månen stod i nedan? Är det sant att vi blir mångalna?</p><p>Och så berättar historikern Lisa Svanfeldt-Winter om sin forskning om 1800-talets vetenskapsdebatt om huruvida jorden var platt. Idag frodas dessa tankar på sociala medier, men redan i mitten av 1800-talet lanserade Samuel Rowbotham sina teorier om en platt jord.</p>",
+                    "id": "11L6kL6k1bSmS61bToXL3g",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a8b3c6c23a2bf767b286e6f27",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f8b3c6c23a2bf767b286e6f27",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d8b3c6c23a2bf767b286e6f27",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "432 – Lisa the Drama Queen",
-                    "release_date": "2022-08-22",
+                    "name": "Människans längtan till månen",
+                    "release_date": "2022-12-06",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:408FVh0BcpDWgoRZGFGnef"
+                    "uri": "spotify:episode:11L6kL6k1bSmS61bToXL3g"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/25ae4c3bd7a93116657d48647e5e1fb19aad65d9",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF21, The Burns and the Bees, the eighth episode of Season Twenty. They talk about bee plots, billionaires, and racist bees. Support the show on Patreon! Listener Question of the Week: Who is your least favorite guest?",
-                    "duration_ms": 5233003,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/31ef36a91ba2fc9bc9cd38b4c174f4d1c8cae340",
+                    "description": "Bänka dig i biofåtöljen och hör historikerna granska bioaktuella The Woman King, om Afrikas amazoner och Devotion - Top Gun i Koreakrigsmiljö! I hundratals år stred kvinnor som elitsoldater i det afrikanska kungariket Dahomeys armé. Nu skildras deras liv och öden i bioaktuella The Woman King och Vetenskapsradion Historia granskar filmens historiska kvalitéer med hjälp av historikern Anders Claréus och diskuterar kvinnliga krigare och kvinnors deltagande i historiska krig med författaren Anna Larsdotter.Dessutom granskar vi aktuella Devotion – en Top Gun-film under Koreakriget där Armémuseets Thomas Roth delar ut betyg.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/5VUBtPTCQf6POQmopNa3ty"
+                        "spotify": "https://open.spotify.com/episode/3CRQcqucr4Qa6Jo7nB53U9"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/5VUBtPTCQf6POQmopNa3ty",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF21, The Burns and the Bees, the eighth episode of Season Twenty. They talk about bee plots, billionaires, and racist bees. Support the show on Patreon! Listener Question of the Week: Who is your least favorite guest?",
-                    "id": "5VUBtPTCQf6POQmopNa3ty",
+                    "href": "https://api.spotify.com/v1/episodes/3CRQcqucr4Qa6Jo7nB53U9",
+                    "html_description": "<p>Bänka dig i biofåtöljen och hör historikerna granska bioaktuella The Woman King, om Afrikas amazoner och Devotion - Top Gun i Koreakrigsmiljö!</p> <p>I hundratals år stred kvinnor som elitsoldater i det afrikanska kungariket Dahomeys armé. Nu skildras deras liv och öden i bioaktuella The Woman King och Vetenskapsradion Historia granskar filmens historiska kvalitéer med hjälp av historikern Anders Claréus och diskuterar kvinnliga krigare och kvinnors deltagande i historiska krig med författaren Anna Larsdotter.</p><p>Dessutom granskar vi aktuella Devotion – en Top Gun-film under Koreakriget där Armémuseets Thomas Roth delar ut betyg.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "3CRQcqucr4Qa6Jo7nB53U9",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a4e038afcbeeb4cdd9915bb28",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f4e038afcbeeb4cdd9915bb28",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d4e038afcbeeb4cdd9915bb28",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "431 – The Burns and the Bees",
-                    "release_date": "2022-08-15",
+                    "name": "Afrikas amazoner på bio",
+                    "release_date": "2022-11-29",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:5VUBtPTCQf6POQmopNa3ty"
+                    "uri": "spotify:episode:3CRQcqucr4Qa6Jo7nB53U9"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/74f8055c5ba544779b7d26dd4e7bbaf0e8522789",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF20, MyPods and Boomsticks, the seventh episode of Season Twenty. They talk about racism, racist jokes, and inexplicable awards. Support us on Patreon! Listener Question of the Week: Who is your favorite female guest star?",
-                    "duration_ms": 6780268,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/63c99681e302c2dc881cc2efaa65f65d723ee560",
+                    "description": "Smutsiga men ståtliga och tatuerade elitkrigare. Så beskrev muslimen Ibn Fadlan sitt möte med vikingar år 922. Men vad berättar han egentligen om relationen mellan nordbor och muslimer? År 922 mötte den muslimske resenären vikingar under sina resor i nuvarande Ryssland. Han beskrev deras barbariska sedvänjor, deras obefintliga personliga hygien, deras tatueringar och hur en hövding begravdes i en båt. Men han talade också om dem som ståtliga och högvuxna krigare. Tobias Svanelid samlas arkeologen Charlotte Hedenstierna Jonsson och religionsvetaren Simon Sorgenfrei för att diskutera vad Ibn Fadlans berättelse betytt för vår förståelse av vikingar, men också vad den kan berätta om relationerna mellan Skandinavien och dåtidens högkultur, de muslimska kalifaten.Dessutom svarar Dick Harrison på en lyssnarfråga om vad vi egentligen vet om slaget vid Herrevadsbro år 1251, slaget som påstås lagt grunden för det moderna Sverige och banat vägen för den nya staden Stockholm.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/5TILQd4YyyzIqOsHAbD3fL"
+                        "spotify": "https://open.spotify.com/episode/04HzXcqi8UoWk1MSrHAqWf"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/5TILQd4YyyzIqOsHAbD3fL",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF20, MyPods and Boomsticks, the seventh episode of Season Twenty. They talk about racism, racist jokes, and inexplicable awards. Support us on Patreon! Listener Question of the Week: Who is your favorite female guest star?",
-                    "id": "5TILQd4YyyzIqOsHAbD3fL",
+                    "href": "https://api.spotify.com/v1/episodes/04HzXcqi8UoWk1MSrHAqWf",
+                    "html_description": "<p>Smutsiga men ståtliga och tatuerade elitkrigare. Så beskrev muslimen Ibn Fadlan sitt möte med vikingar år 922. Men vad berättar han egentligen om relationen mellan nordbor och muslimer?</p> <p>År 922 mötte den muslimske resenären vikingar under sina resor i nuvarande Ryssland. Han beskrev deras barbariska sedvänjor, deras obefintliga personliga hygien, deras tatueringar och hur en hövding begravdes i en båt. Men han talade också om dem som ståtliga och högvuxna krigare. Tobias Svanelid samlas arkeologen Charlotte Hedenstierna Jonsson och religionsvetaren Simon Sorgenfrei för att diskutera vad Ibn Fadlans berättelse betytt för vår förståelse av vikingar, men också vad den kan berätta om relationerna mellan Skandinavien och dåtidens högkultur, de muslimska kalifaten.</p><p>Dessutom svarar Dick Harrison på en lyssnarfråga om vad vi egentligen vet om slaget vid Herrevadsbro år 1251, slaget som påstås lagt grunden för det moderna Sverige och banat vägen för den nya staden Stockholm.</p>",
+                    "id": "04HzXcqi8UoWk1MSrHAqWf",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ab7604c0461bd9a2489f58a03",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fb7604c0461bd9a2489f58a03",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68db7604c0461bd9a2489f58a03",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "430 – Mypods and Boomsticks",
-                    "release_date": "2022-08-08",
+                    "name": "Ibn Fadlans möte med vikingar",
+                    "release_date": "2022-11-22",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:5TILQd4YyyzIqOsHAbD3fL"
+                    "uri": "spotify:episode:04HzXcqi8UoWk1MSrHAqWf"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/06b23069ebeec2f8d6914ba27f3a235d0b1c3e98",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF19, Homer and Lisa Exchange Cross Words, the sixth episode of Season Twenty. They talk about crossword puzzles, pointless B plots, and Homer infecting the A plot. Support us on Patreon! Listener Question of the Week: Who is your favorite lesser-known guess star?",
-                    "duration_ms": 4832065,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f7cdd266162f0024036f4c54a443c5275cda2a67",
+                    "description": "Omkring 300 människor miste livet i det kalla novembervattnet 1872, när havet höjdes drygt 3 meter och slog sönder kusterna längs södra Östersjön. Vi söker spåren efter denna bortglömda katastrof. För 150 år sedan översköljdes Östersjöns kuster av en stormflod. Havsnivån höjdes på sina ställen med mer än tre meter och hundratals människor drunknade i det iskalla vattnet. Tobias Svanelid vandrar runt på Falsterbonäset där det fortfarande finns spår kvar efter stormfloden 1872, och träffar kustingenjören Caroline Hallin som berättar om katastrofen och vad vi idag kan lära av den.Och så uppmärksammar vi tidskapseln från Storkyrkan som presenterades för allmänheten tidigare i höstas, men som bär på ytterligare dolda budskap.Dessutom granskar vi Netflixfilmen På västfronten intet nytt och tar reda på vad den kan säga om vår tids skyttegravskrig i Ukraina.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/6S7wsQUOYL961XOa5UvItx"
+                        "spotify": "https://open.spotify.com/episode/5vuboOq73oBTsTumCHE3E8"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/6S7wsQUOYL961XOa5UvItx",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF19, Homer and Lisa Exchange Cross Words, the sixth episode of Season Twenty. They talk about crossword puzzles, pointless B plots, and Homer infecting the A plot. Support us on Patreon! Listener Question of the Week: Who is your favorite lesser-known guess star?",
-                    "id": "6S7wsQUOYL961XOa5UvItx",
+                    "href": "https://api.spotify.com/v1/episodes/5vuboOq73oBTsTumCHE3E8",
+                    "html_description": "<p>Omkring 300 människor miste livet i det kalla novembervattnet 1872, när havet höjdes drygt 3 meter och slog sönder kusterna längs södra Östersjön. Vi söker spåren efter denna bortglömda katastrof.</p> <p>För 150 år sedan översköljdes Östersjöns kuster av en stormflod. Havsnivån höjdes på sina ställen med mer än tre meter och hundratals människor drunknade i det iskalla vattnet. Tobias Svanelid vandrar runt på Falsterbonäset där det fortfarande finns spår kvar efter stormfloden 1872, och träffar kustingenjören Caroline Hallin som berättar om katastrofen och vad vi idag kan lära av den.</p><p>Och så uppmärksammar vi tidskapseln från Storkyrkan som presenterades för allmänheten tidigare i höstas, men som bär på ytterligare dolda budskap.</p><p>Dessutom granskar vi Netflixfilmen På västfronten intet nytt och tar reda på vad den kan säga om vår tids skyttegravskrig i Ukraina.</p>",
+                    "id": "5vuboOq73oBTsTumCHE3E8",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ad788851b76498f5c9b55dbad",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fd788851b76498f5c9b55dbad",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dd788851b76498f5c9b55dbad",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "429 – Homer and Lisa Exchange Cross Words",
-                    "release_date": "2022-08-01",
+                    "name": "Stormfloden 1872",
+                    "release_date": "2022-11-15",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:6S7wsQUOYL961XOa5UvItx"
+                    "uri": "spotify:episode:5vuboOq73oBTsTumCHE3E8"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/966f3d71dfd7986457109b9f26d73fa4e61ae8dc",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF18, Dangerous Curves, the fifth episode of Season Twenty. They talk about non-linear storytelling, unrecognizable characters, and relationship episodes. Order Killer Hockey Mascot! Support us on Patreon! Listener Question of the Week: What’s your favorite quote from a flashback episode?",
-                    "duration_ms": 5417533,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/dfc72b57909555fcca6b5eff6622276919e2142e",
+                    "description": "Var det bläckfiskar, hajar eller galna mördare som orsakade Mary Celestes undergång. I 150 år har man nu spekulerat om spökskeppets öde och varför besättningen var spårlöst försvunnen. I november 1872, för 150 år sedan, satte Mary Celeste segel för sin resa över Atlanten. Några veckor senare hittas hon drivande i vågorna utanför Portugals kust. Hennes besättning är spårlöst försvunnen. Allt sedan dess har spekulationerna om vad som hände Mary Celeste varit många och Tobias Svanelid reder ut bland teorierna om spökskeppets öden och äventyr, bland hajar, bläckfiskar, galna mördare och explosioner.Dessutom svarar Dick Harrison på en lyssnarfråga om varför Norge blev monarki och inte republik vid unionsupplösningen 1905.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/3oENRT0e2sFSVfEuwgXSPK"
+                        "spotify": "https://open.spotify.com/episode/6T7xgiOEJ8advsXfZOfiEL"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/3oENRT0e2sFSVfEuwgXSPK",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF18, Dangerous Curves, the fifth episode of Season Twenty. They talk about non-linear storytelling, unrecognizable characters, and relationship episodes. Order Killer Hockey Mascot! Support us on Patreon! Listener Question of the Week: What’s your favorite quote from a flashback episode?",
-                    "id": "3oENRT0e2sFSVfEuwgXSPK",
+                    "href": "https://api.spotify.com/v1/episodes/6T7xgiOEJ8advsXfZOfiEL",
+                    "html_description": "<p>Var det bläckfiskar, hajar eller galna mördare som orsakade Mary Celestes undergång. I 150 år har man nu spekulerat om spökskeppets öde och varför besättningen var spårlöst försvunnen.</p> <p>I november 1872, för 150 år sedan, satte Mary Celeste segel för sin resa över Atlanten. Några veckor senare hittas hon drivande i vågorna utanför Portugals kust. Hennes besättning är spårlöst försvunnen. Allt sedan dess har spekulationerna om vad som hände Mary Celeste varit många och Tobias Svanelid reder ut bland teorierna om spökskeppets öden och äventyr, bland hajar, bläckfiskar, galna mördare och explosioner.</p><p>Dessutom svarar Dick Harrison på en lyssnarfråga om varför Norge blev monarki och inte republik vid unionsupplösningen 1905.</p>",
+                    "id": "6T7xgiOEJ8advsXfZOfiEL",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aaf8163b0c72ce6d3cb92042f",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1faf8163b0c72ce6d3cb92042f",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68daf8163b0c72ce6d3cb92042f",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "428 – Dangerous Curves",
-                    "release_date": "2022-07-25",
+                    "name": "Spökskeppet Mary Celeste",
+                    "release_date": "2022-11-08",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:3oENRT0e2sFSVfEuwgXSPK"
+                    "uri": "spotify:episode:6T7xgiOEJ8advsXfZOfiEL"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/840b2b51b25293e7101557b7e6a0918f23880d86",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF16, Treehouse of Horror XIX, the fourth episode of Season Twenty. They talk about tepid parodies, zero jokes, and Charlie Brown. Pre-Order Killer Hockey Mascot! Support us on Patreon! Listener Question of the Week: What’s your favorite TOH quote?",
-                    "duration_ms": 4235332,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/feda4d72714de4e6885323985448409b039f7ffb",
+                    "description": "Han var en av Egyptens kortast regerande faraoner och dog knappt 20 år gammal. Ändå skulle upptäckten av hans grav ta världen med storm och orsaka faraos förbannelse. ”Jag ser underbara ting” rapporterade Howard Carter när han som första människa på mer än 3000 år kikade in i Tutanchamons grav för exakt 100 år sedan. Vetenskapsradion Historia berättar om upptäckten som tog världen med storm och födde en Egyptenfeber utan like. Och som dessutom följdes av flertalet mystiska dödsfall – men vad ligger det egentligen för sanning i påståendena om mumiens förbannelse?Panelen med Jonathan Lindström och Kristina Ekero Eriksson återsamlas också för att diskutera andra banbrytande upptäckter i skuggan av Tutanchamon, och om de själva känt av förhistoriska förbannelser under sina egna arkeologiska utgrävningar.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/227cdrDgjbfeGVmQuz0Zne"
+                        "spotify": "https://open.spotify.com/episode/74unMg1Sta60SZV5gdjSqC"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/227cdrDgjbfeGVmQuz0Zne",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF16, Treehouse of Horror XIX, the fourth episode of Season Twenty. They talk about tepid parodies, zero jokes, and Charlie Brown. Pre-Order Killer Hockey Mascot! Support us on Patreon! Listener Question of the Week: What’s your favorite TOH quote?",
-                    "id": "227cdrDgjbfeGVmQuz0Zne",
+                    "href": "https://api.spotify.com/v1/episodes/74unMg1Sta60SZV5gdjSqC",
+                    "html_description": "<p>Han var en av Egyptens kortast regerande faraoner och dog knappt 20 år gammal. Ändå skulle upptäckten av hans grav ta världen med storm och orsaka faraos förbannelse.</p> <p>”Jag ser underbara ting” rapporterade Howard Carter när han som första människa på mer än 3000 år kikade in i Tutanchamons grav för exakt 100 år sedan. Vetenskapsradion Historia berättar om upptäckten som tog världen med storm och födde en Egyptenfeber utan like. Och som dessutom följdes av flertalet mystiska dödsfall – men vad ligger det egentligen för sanning i påståendena om mumiens förbannelse?</p><p>Panelen med Jonathan Lindström och Kristina Ekero Eriksson återsamlas också för att diskutera andra banbrytande upptäckter i skuggan av Tutanchamon, och om de själva känt av förhistoriska förbannelser under sina egna arkeologiska utgrävningar.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "74unMg1Sta60SZV5gdjSqC",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a5a283aa2fb103f081f170b34",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f5a283aa2fb103f081f170b34",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d5a283aa2fb103f081f170b34",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "427 – Treehouse of Horror XIX",
-                    "release_date": "2022-07-18",
+                    "name": "Tutanchamonfeber i hundra år",
+                    "release_date": "2022-11-01",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:227cdrDgjbfeGVmQuz0Zne"
+                    "uri": "spotify:episode:74unMg1Sta60SZV5gdjSqC"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/a7457f825eb62fb0eb21201c00059f1cd5a37d1e",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF14, Double, Double, Boy in Trouble, the third episode of Season Twenty. They talk about doppelgangers, logistics, and robot vacuums. Pre-Order Killer Hockey Mascot! Support us on Patreon! Listener Question of the Week: What’s your favorite Lenny moment?",
-                    "duration_ms": 5101478,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/5f4865ed84fe62992b252d8207f403181febe503",
+                    "description": "Vilka argument kan motivera ett anfallskrig. Genom årtusendena har stater, kungar och presidenter försökt rättfärdiga sina aggressionskrig och Vetenskapsradion Historia kartlägger argumenten. Vi har rätten på vår sida. Vi är starkare. Motståndarna torterar våra vänner eller är nazister. Och det var fienden som sköt först. Så lyder anfallskrigens argument genom historien, från det antika Atens anfall på ön Melos, via Gustav III:s anfall på Ryssland och Putins anfall mot Ukraina. Vi träffar folkrättsexperten Ove Bring som undersökt anfallskrigens argument i en aktuell bok.Vi uppmärksammar också det nya fyndet av regalskeppet Äpplet, Vasaskeppets systerfartyg, som hittats på bottnen utanför Vaxholm.Dessutom reder Dick Harrison ut en lyssnarfråga om Ragnar Lodbrok. Vad vet vi egentligen om denna vikingahövdings existens?Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/1zrTXAm02Yom4UigtjhbO7"
+                        "spotify": "https://open.spotify.com/episode/5glIX0MIjLjBLrxKzRhgNq"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/1zrTXAm02Yom4UigtjhbO7",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF14, Double, Double, Boy in Trouble, the third episode of Season Twenty. They talk about doppelgangers, logistics, and robot vacuums. Pre-Order Killer Hockey Mascot! Support us on Patreon! Listener Question of the Week: What’s your favorite Lenny moment?",
-                    "id": "1zrTXAm02Yom4UigtjhbO7",
+                    "href": "https://api.spotify.com/v1/episodes/5glIX0MIjLjBLrxKzRhgNq",
+                    "html_description": "<p>Vilka argument kan motivera ett anfallskrig. Genom årtusendena har stater, kungar och presidenter försökt rättfärdiga sina aggressionskrig och Vetenskapsradion Historia kartlägger argumenten.</p> <p>Vi har rätten på vår sida. Vi är starkare. Motståndarna torterar våra vänner eller är nazister. Och det var fienden som sköt först. Så lyder anfallskrigens argument genom historien, från det antika Atens anfall på ön Melos, via Gustav III:s anfall på Ryssland och Putins anfall mot Ukraina. Vi träffar folkrättsexperten Ove Bring som undersökt anfallskrigens argument i en aktuell bok.</p><p>Vi uppmärksammar också det nya fyndet av regalskeppet Äpplet, Vasaskeppets systerfartyg, som hittats på bottnen utanför Vaxholm.</p><p>Dessutom reder Dick Harrison ut en lyssnarfråga om Ragnar Lodbrok. Vad vet vi egentligen om denna vikingahövdings existens?</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "5glIX0MIjLjBLrxKzRhgNq",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aecb4ef4fc72d026f57a0ad41",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fecb4ef4fc72d026f57a0ad41",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68decb4ef4fc72d026f57a0ad41",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "426 – Double, Double, Boy in Trouble",
-                    "release_date": "2022-07-11",
+                    "name": "Därför startar vi krig",
+                    "release_date": "2022-10-25",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:1zrTXAm02Yom4UigtjhbO7"
+                    "uri": "spotify:episode:5glIX0MIjLjBLrxKzRhgNq"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/df69d034e44d488b4b7d8550efe4f5907d98c712",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF15, Lost Verizon, the second episode of Season Twenty. They talk about nonsense, filler, and Incan dieties. Pre-Order Killer Hockey Mascot Support us on Patreon! Listener Question of the Week: What’s your favorite Groundskeeper Willie quote?",
-                    "duration_ms": 5100805,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/98398bbc6ac9c60553b8823059bbc8e31024996f",
+                    "description": "Nu återskapas två historiska spritsorter som kan skänka smaken av 1600-talet. Hör Vetenskapsradion Historia testa Vasaskeppets brännvin och 1700-talets mirakelkur - nu utan huggormskött! En tydlig ton av anis präglar brännvinet som hittades ombord på Vasaskeppet när hon bärgades. Nu har spriten återskapats och Vetenskapsradion Historia uppmärksammar detta kanske världens äldsta bevarade brännvin, och diskuterar också konsten och utmaningarna med att återskapa historisk sprit. För samtidigt som Vasadrycken lanseras kommer också 1700-talets mirakelmedicin Hjärnes Testamente ut i handeln, men där tillverkarna fått utesluta bland annat originalingredienserna huggorm och opium.Dessutom uppmärksammar vi Ettans snus som fyller 200 år och därmed blivit Sveriges kanske äldsta varumärke som fortfarande finns i livsmedelshandeln. Hur väl liknar dagens snus 1820-talets?Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/4Y8Hch3ayqTVXYOukIX2b5"
+                        "spotify": "https://open.spotify.com/episode/4SEMDUbGpUWFcTQk62e5ox"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/4Y8Hch3ayqTVXYOukIX2b5",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF15, Lost Verizon, the second episode of Season Twenty. They talk about nonsense, filler, and Incan dieties. Pre-Order Killer Hockey Mascot Support us on Patreon! Listener Question of the Week: What’s your favorite Groundskeeper Willie quote?",
-                    "id": "4Y8Hch3ayqTVXYOukIX2b5",
+                    "href": "https://api.spotify.com/v1/episodes/4SEMDUbGpUWFcTQk62e5ox",
+                    "html_description": "<p>Nu återskapas två historiska spritsorter som kan skänka smaken av 1600-talet. Hör Vetenskapsradion Historia testa Vasaskeppets brännvin och 1700-talets mirakelkur - nu utan huggormskött!</p> <p>En tydlig ton av anis präglar brännvinet som hittades ombord på Vasaskeppet när hon bärgades. Nu har spriten återskapats och Vetenskapsradion Historia uppmärksammar detta kanske världens äldsta bevarade brännvin, och diskuterar också konsten och utmaningarna med att återskapa historisk sprit. För samtidigt som Vasadrycken lanseras kommer också 1700-talets mirakelmedicin Hjärnes Testamente ut i handeln, men där tillverkarna fått utesluta bland annat originalingredienserna huggorm och opium.</p><p>Dessutom uppmärksammar vi Ettans snus som fyller 200 år och därmed blivit Sveriges kanske äldsta varumärke som fortfarande finns i livsmedelshandeln. Hur väl liknar dagens snus 1820-talets?</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "4SEMDUbGpUWFcTQk62e5ox",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a4f54e7a23f621e24a3785d64",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f4f54e7a23f621e24a3785d64",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d4f54e7a23f621e24a3785d64",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "425 – Lost Verizon",
-                    "release_date": "2022-07-04",
+                    "name": "Så smakar Vasas brännvin",
+                    "release_date": "2022-10-18",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:4Y8Hch3ayqTVXYOukIX2b5"
+                    "uri": "spotify:episode:4SEMDUbGpUWFcTQk62e5ox"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d35b0bd15b61b335d46cf3fc369cf22332c76fdc",
-                    "description": "Tonight, we are joined by cartoonist Jeff Martin to discuss Episode KABF17, Sex, Pies, and Idiot Scrapes, the first episode of Season Twenty. They talk about erotic bakeries, bounty hunting, and parkour. Crowdfund Jeff’s new book, Hockeypocalypse: Slashers! Listen to Robbie’s appearance on the Juras-Sick Park-cast! Support us on Patreon! Listener Question of the Week:Continue Reading…",
-                    "duration_ms": 7440614,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/6eb73b9571cc30c039f8d5a08464e92c6f2e67ec",
+                    "description": "Under hundratals år levde många svenskar säsongsvis vid Norrlandskusten för att fiska i Bottenviken. Fiskarkapellen var mötespunkten som skänkte trygghet och tröst och nu kartläggs deras kulturarv. För 400 år sedan började mellansvenska bönder resa till Norrlandskusten för att fiska. Ofta tog man med sig hela familjen och gårdens djur och tjänstefolk och var borta hela sommaren. Under det hårda livet bland Höga Kustens kobbar och skär var fiskekapellen ofta den enda trösten. Idag vittnar de om ett månghundraårigt kulturarv och nu har kapellen i Ångermanland och Medelpad undersökts. Vetenskapsradion Historia besöker Barsta kapell för att berätta fiskarkapellens spännande historia.Dessutom svarar Dick Harrison på en lyssnarfråga om svedjefinnarnas historia i Värmland – hur länge bibehöll man sina finska traditioner och finska namn egentligen?Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/1bviTTWtuWZ4xdPQms9Cc4"
+                        "spotify": "https://open.spotify.com/episode/2sSYWETyAk9LcUSkX5Z2GE"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/1bviTTWtuWZ4xdPQms9Cc4",
-                    "html_description": "Tonight, we are joined by cartoonist Jeff Martin to discuss Episode KABF17, Sex, Pies, and Idiot Scrapes, the first episode of Season Twenty. They talk about erotic bakeries, bounty hunting, and parkour. Crowdfund Jeff’s new book, Hockeypocalypse: Slashers! Listen to Robbie’s appearance on the Juras-Sick Park-cast! Support us on Patreon! Listener Question of the Week:<p>Continue Reading…</p>",
-                    "id": "1bviTTWtuWZ4xdPQms9Cc4",
+                    "href": "https://api.spotify.com/v1/episodes/2sSYWETyAk9LcUSkX5Z2GE",
+                    "html_description": "<p>Under hundratals år levde många svenskar säsongsvis vid Norrlandskusten för att fiska i Bottenviken. Fiskarkapellen var mötespunkten som skänkte trygghet och tröst och nu kartläggs deras kulturarv.</p> <p>För 400 år sedan började mellansvenska bönder resa till Norrlandskusten för att fiska. Ofta tog man med sig hela familjen och gårdens djur och tjänstefolk och var borta hela sommaren. Under det hårda livet bland Höga Kustens kobbar och skär var fiskekapellen ofta den enda trösten. Idag vittnar de om ett månghundraårigt kulturarv och nu har kapellen i Ångermanland och Medelpad undersökts. Vetenskapsradion Historia besöker Barsta kapell för att berätta fiskarkapellens spännande historia.</p><p>Dessutom svarar Dick Harrison på en lyssnarfråga om svedjefinnarnas historia i Värmland – hur länge bibehöll man sina finska traditioner och finska namn egentligen?</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "2sSYWETyAk9LcUSkX5Z2GE",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a9b739e5f95a69eabac3af252",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f9b739e5f95a69eabac3af252",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d9b739e5f95a69eabac3af252",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "424 – Sex, Pies, and Idiot Scrapes (w Jeff Martin)",
-                    "release_date": "2022-06-27",
+                    "name": "Fiskarkapellens spännande kulturarv",
+                    "release_date": "2022-10-11",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:1bviTTWtuWZ4xdPQms9Cc4"
+                    "uri": "spotify:episode:2sSYWETyAk9LcUSkX5Z2GE"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/9a21ac014ead3cc9c04d334f8f7c7dc3aa1a2175",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF13, All About Lisa, the twentieth and final episode of Season Nineteen. They talk about Hollywood, fame, and coin collecting. Support us on Patreon! Listener Question of the Week: What’s your favorite moment from Season 19?",
-                    "duration_ms": 5028162,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/9c7643fb9ad38cf1858bd3580e9c6339d825a5e0",
+                    "description": "Hur såg hallen ut där Uppåkras mäktiga hövdingar en gång bodde och höll hov och där de smidde planer för det förhistoriska Skåne i kamp mot daner och svear? Snart vet vi svaret! I mer än 1000 år dominerade Uppåkra de rika jordbruksbygderna i Skåne, och trots att inte mer än någon promille grävts ut av arkeologer har redan makalösa fynd gjorts. Nu tas nya spadtag på platsen i jakt efter hövdingahallen i Uppåkra, där stolta dynastier avlöst varandra under många sekel.Tobias Svanelid promenerar runt i Uppåkra med Dick Harrison som i sin aktuella bok Tusen år i Uppåkra målar upp bilden av ett mäktigt hövdingadöme, där de rika makthavarna sannolikt kontrollerade den religiösa kulten som de styrde ifrån sin hall och ifrån det mystiska kulthus som redan varit känt av arkeologerna. Kanske tillhörde de stammen harubarder, ett mytomspunnet folk som verkar ha kämpat med daner om makten runt Öresund.Dessutom redogör arkeologerna Mats Roslund, Torbjörn Ahlström och Håkan Aspeborg för de kommande unika utgrävningar som nu planeras vid hövdingahallen och som kommer att sprida nytt ljus över platsen som så länge utgjorde en stabil maktbas i södra Skandinavien.Och så tar vi en snabbtitt på de pågående arkeologiska undersökningarna på Gotska sandön, där säljägare och fiskare bott och verkat i fyratusen år. ",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/37V6zfOgwvGR4vZ8sk2Acj"
+                        "spotify": "https://open.spotify.com/episode/6PfvaqgLWebJioqPv3Tpfc"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/37V6zfOgwvGR4vZ8sk2Acj",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF13, All About Lisa, the twentieth and final episode of Season Nineteen. They talk about Hollywood, fame, and coin collecting. Support us on Patreon! Listener Question of the Week: What’s your favorite moment from Season 19?",
-                    "id": "37V6zfOgwvGR4vZ8sk2Acj",
+                    "href": "https://api.spotify.com/v1/episodes/6PfvaqgLWebJioqPv3Tpfc",
+                    "html_description": "<p>Hur såg hallen ut där Uppåkras mäktiga hövdingar en gång bodde och höll hov och där de smidde planer för det förhistoriska Skåne i kamp mot daner och svear? Snart vet vi svaret!</p> <p>I mer än 1000 år dominerade Uppåkra de rika jordbruksbygderna i Skåne, och trots att inte mer än någon promille grävts ut av arkeologer har redan makalösa fynd gjorts. Nu tas nya spadtag på platsen i jakt efter hövdingahallen i Uppåkra, där stolta dynastier avlöst varandra under många sekel.</p><p>Tobias Svanelid promenerar runt i Uppåkra med Dick Harrison som i sin aktuella bok Tusen år i Uppåkra målar upp bilden av ett mäktigt hövdingadöme, där de rika makthavarna sannolikt kontrollerade den religiösa kulten som de styrde ifrån sin hall och ifrån det mystiska kulthus som redan varit känt av arkeologerna. Kanske tillhörde de stammen harubarder, ett mytomspunnet folk som verkar ha kämpat med daner om makten runt Öresund.</p><p>Dessutom redogör arkeologerna Mats Roslund, Torbjörn Ahlström och Håkan Aspeborg för de kommande unika utgrävningar som nu planeras vid hövdingahallen och som kommer att sprida nytt ljus över platsen som så länge utgjorde en stabil maktbas i södra Skandinavien.</p><p>Och så tar vi en snabbtitt på de pågående arkeologiska undersökningarna på Gotska sandön, där säljägare och fiskare bott och verkat i fyratusen år.</p><p> </p>",
+                    "id": "6PfvaqgLWebJioqPv3Tpfc",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aa255259e1238f1b559dcbaef",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fa255259e1238f1b559dcbaef",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68da255259e1238f1b559dcbaef",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "423 – All About Lisa",
-                    "release_date": "2022-06-20",
+                    "name": "Uppåkras hövdingahall grävs ut",
+                    "release_date": "2022-10-04",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:37V6zfOgwvGR4vZ8sk2Acj"
+                    "uri": "spotify:episode:6PfvaqgLWebJioqPv3Tpfc"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/898289e7fd723dc4851aaeb50494038e5d859214",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF12, Mona Leaves-a, the nineteenth episode of Season Nineteen. They talk about Mona, missile silos, and processing grief. Support us on Patreon! Listener Question of the Week: What’s your favorite fictional death?",
-                    "duration_ms": 6383419,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/955aa2926f9395e83fd80b007c2b3fb6aeacc782",
+                    "description": "För 200 år sedan knäcktes hieroglyfernas gåta med hjälp av texterna på den uråldriga Rosettastenen. Vi berättar hur det gick till, men också om Egyptens mumier som nu föräras en egen bok. För 200 år sedan rusade språkvetaren Champollion till sin bror och utropade att han knäckt hieroglyfernas gåta. Vetenskapsradion Historia berättar historien om Rosettastenen som hittades i slutet av 1700-talet och som fungerade som en nyckel för att dechiffrera det fornegyptiska språket. Och om att en av nyckelpersonerna i pusslet faktiskt var svensk, Johan David Åkerblad, berättar historikern Fredrik Thomasson.Dessutom berättas de egyptiska mumiernas historia med anledning av aktuella boken Mumier. Egyptologen Sofia Häggman menar att det tog lång tid för de gamla egyptierna att bemästra den svåra konsten, som delvis påminner om ett PCR-test, och vi idag ofta glömmer att mumierna faktiskt är mänskliga kvarlevor och inte bara ett mytiskt väsen tillsammans med varulvar och vampyrer.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/19j7F0IUnLhye0a6OIoFbp"
+                        "spotify": "https://open.spotify.com/episode/0QTLz2FQ7Ih4UDbnFfK5Ig"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/19j7F0IUnLhye0a6OIoFbp",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF12, Mona Leaves-a, the nineteenth episode of Season Nineteen. They talk about Mona, missile silos, and processing grief. Support us on Patreon! Listener Question of the Week: What’s your favorite fictional death?",
-                    "id": "19j7F0IUnLhye0a6OIoFbp",
+                    "href": "https://api.spotify.com/v1/episodes/0QTLz2FQ7Ih4UDbnFfK5Ig",
+                    "html_description": "<p>För 200 år sedan knäcktes hieroglyfernas gåta med hjälp av texterna på den uråldriga Rosettastenen. Vi berättar hur det gick till, men också om Egyptens mumier som nu föräras en egen bok.</p> <p>För 200 år sedan rusade språkvetaren Champollion till sin bror och utropade att han knäckt hieroglyfernas gåta. Vetenskapsradion Historia berättar historien om Rosettastenen som hittades i slutet av 1700-talet och som fungerade som en nyckel för att dechiffrera det fornegyptiska språket. Och om att en av nyckelpersonerna i pusslet faktiskt var svensk, Johan David Åkerblad, berättar historikern Fredrik Thomasson.</p><p>Dessutom berättas de egyptiska mumiernas historia med anledning av aktuella boken Mumier. Egyptologen Sofia Häggman menar att det tog lång tid för de gamla egyptierna att bemästra den svåra konsten, som delvis påminner om ett PCR-test, och vi idag ofta glömmer att mumierna faktiskt är mänskliga kvarlevor och inte bara ett mytiskt väsen tillsammans med varulvar och vampyrer.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "0QTLz2FQ7Ih4UDbnFfK5Ig",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ab386237c9df1a5b287ccd89a",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fb386237c9df1a5b287ccd89a",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68db386237c9df1a5b287ccd89a",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "422 – Mona Leaves-a",
-                    "release_date": "2022-06-13",
+                    "name": "När hieroglyferna knäcktes",
+                    "release_date": "2022-09-27",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:19j7F0IUnLhye0a6OIoFbp"
+                    "uri": "spotify:episode:0QTLz2FQ7Ih4UDbnFfK5Ig"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/d258e9ec584677f17441228967a2dc5df6a0ad55",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF11, Any Given Sundance, the eighteenth episode of Season Nineteen. They talk about indie film, Lisa, and Jim Jarmusch. Support us on Patreon! Listener Question of the Week: What’s your favorite John C Reilly performance?",
-                    "duration_ms": 4397683,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/1a1a7df417e12bafcf40ebe83b142a9503f9d256",
+                    "description": "Följ med till Bulverket - medeltidens sjunkna Atlantis - en gigantisk träplattform full av hus som nu kan avslöja 1000-åriga byggnadstekniker och vad plattformen en gång haft för funktion. I början av medeltiden byggdes en enorm plattform av timmer ute i den grunda sjön Tingstäde träsk på Gotland. En kort tid senare övergavs platsen men ännu idag är bygget synligt som ett gigantiskt plockepinn någon meter under vattenytan. Tobias Svanelid hoppar i gummibåten tillsammans med arkeologen Peter d’Agnan för att ta reda på vad Bulverket kan ha fyllt för funktion och för att fascineras av de extremt välbevarade träresterna som kan avslöja medeltidens byggnadstekniker.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/3zwHZvhqrLJD4lSsyFKUkz"
+                        "spotify": "https://open.spotify.com/episode/6JjK4uJaxMh3DV6FJDP571"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/3zwHZvhqrLJD4lSsyFKUkz",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF11, Any Given Sundance, the eighteenth episode of Season Nineteen. They talk about indie film, Lisa, and Jim Jarmusch. Support us on Patreon! Listener Question of the Week: What’s your favorite John C Reilly performance?",
-                    "id": "3zwHZvhqrLJD4lSsyFKUkz",
+                    "href": "https://api.spotify.com/v1/episodes/6JjK4uJaxMh3DV6FJDP571",
+                    "html_description": "<p>Följ med till Bulverket - medeltidens sjunkna Atlantis - en gigantisk träplattform full av hus som nu kan avslöja 1000-åriga byggnadstekniker och vad plattformen en gång haft för funktion.</p> <p>I början av medeltiden byggdes en enorm plattform av timmer ute i den grunda sjön Tingstäde träsk på Gotland. En kort tid senare övergavs platsen men ännu idag är bygget synligt som ett gigantiskt plockepinn någon meter under vattenytan. Tobias Svanelid hoppar i gummibåten tillsammans med arkeologen Peter d’Agnan för att ta reda på vad Bulverket kan ha fyllt för funktion och för att fascineras av de extremt välbevarade träresterna som kan avslöja medeltidens byggnadstekniker.</p>",
+                    "id": "6JjK4uJaxMh3DV6FJDP571",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a7adf99961dcffc84f2d22ec5",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f7adf99961dcffc84f2d22ec5",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d7adf99961dcffc84f2d22ec5",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "421 – Any Given Sundance",
-                    "release_date": "2022-06-06",
+                    "name": "Bulverket – medeltidens sjunkna Atlantis",
+                    "release_date": "2022-09-20",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:3zwHZvhqrLJD4lSsyFKUkz"
+                    "uri": "spotify:episode:6JjK4uJaxMh3DV6FJDP571"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/cecba35750250a1a2af5a6ba717f83def439cdd8",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF10, Apocalypse Cow, the seventeenth episode of Season Nineteen. They talk about cows, endless montages, and hilbilly jokes. Support us on Patreon! Listener Question of the Week: What’s your favorite Cletus quote?",
-                    "duration_ms": 5936513,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/91662050a136b9aae974fa86c3ea8efe6f2ce0ca",
+                    "description": "En bonde med en kniv eller yxa i handen. Så såg 1600-talets typiska mördare ut visar den senaste forskningen som också försöker förstå varför dödligt våld blivit så mycket ovanligare i vår egen tid. Antalet mord och dråp i Sverige har minskat avsevärt de senaste 400 åren. Vetenskapsradion Historia undersöker hur det kommer sig och hur det dödliga våldet såg ut på 1600-talet. I en ny forskningsrapport undersöker historikern Dag Lindström hur det dödliga våldet såg ut på 1640-talet, och kan visa att den typiska mördaren då var en bonde som tog livet av en nära vän eller granne i sitt eget hem med hjälp av ett skarpt föremål.Dessutom berättar historikern Gunnar Wetterberg om prästernas långa historia i Sverige – landets kanske viktigaste och mest inflytelserika yrkesgrupp som har tröstat och förmanat, begravt, vigt, döpt och predikat i tusen år. I hans aktuella bok Prästerna lyfts deras insats upp i ljuset.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685504,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/6AInd3aWXeEqE5mu7GNxaL"
+                        "spotify": "https://open.spotify.com/episode/5d8CxZvDo2eDyX6CuXze1M"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/6AInd3aWXeEqE5mu7GNxaL",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF10, Apocalypse Cow, the seventeenth episode of Season Nineteen. They talk about cows, endless montages, and hilbilly jokes. Support us on Patreon! Listener Question of the Week: What’s your favorite Cletus quote?",
-                    "id": "6AInd3aWXeEqE5mu7GNxaL",
+                    "href": "https://api.spotify.com/v1/episodes/5d8CxZvDo2eDyX6CuXze1M",
+                    "html_description": "<p>En bonde med en kniv eller yxa i handen. Så såg 1600-talets typiska mördare ut visar den senaste forskningen som också försöker förstå varför dödligt våld blivit så mycket ovanligare i vår egen tid.</p> <p>Antalet mord och dråp i Sverige har minskat avsevärt de senaste 400 åren. Vetenskapsradion Historia undersöker hur det kommer sig och hur det dödliga våldet såg ut på 1600-talet. I en ny forskningsrapport undersöker historikern Dag Lindström hur det dödliga våldet såg ut på 1640-talet, och kan visa att den typiska mördaren då var en bonde som tog livet av en nära vän eller granne i sitt eget hem med hjälp av ett skarpt föremål.</p><p>Dessutom berättar historikern Gunnar Wetterberg om prästernas långa historia i Sverige – landets kanske viktigaste och mest inflytelserika yrkesgrupp som har tröstat och förmanat, begravt, vigt, döpt och predikat i tusen år. I hans aktuella bok Prästerna lyfts deras insats upp i ljuset.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "5d8CxZvDo2eDyX6CuXze1M",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ae82dcabc6ae42ceeb3f70eea",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fe82dcabc6ae42ceeb3f70eea",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68de82dcabc6ae42ceeb3f70eea",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "420 – Apocalypse Cow",
-                    "release_date": "2022-05-30",
+                    "name": "1600-talets dödliga våld utreds",
+                    "release_date": "2022-09-13",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:6AInd3aWXeEqE5mu7GNxaL"
+                    "uri": "spotify:episode:5d8CxZvDo2eDyX6CuXze1M"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/481c378cb83bf43b8062b1cdc3167db1b4105b5c",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF09, Papa Don’t Leech, the sixteenth episode of Season Nineteen. They talk about Lurleen, murderous Homer, and deadbeat dads. Support us on Patreon! Listener Question of the Week: What one-off guest character would you bring back?",
-                    "duration_ms": 5732647,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/28d0ae229d3f3c06689f60b66e1722a9585639a4",
+                    "description": "Sverige hade kunnat bli symbolen för frihet, jämlikhet och broderskap om det inte varit för Gustav III:s statskupp för 250 år sedan. Hör om den och om klimatkrisen 1770 som pågick samtidigt. För 250 år sedan ställdes Sverige på ända. De demokratiska tendenser som börjat spira under Frihetstiden slog i ett slag sönder av Gustav III under hans statskupp. Vetenskapsradion Historia tar med sig historikern Jonas Nordin till Stockholms slott för att ta reda på hur kungen lyckades med kuppen och vilka politiska konsekvenser den fick för Sverige. Och vad som hade hänt om kuppen misslyckats?Dessutom lyfter historikern Dominik Collet upp den allvarliga klimatkrisen under 1770-talet som en okänd anledning till att statskuppen lyckades. I missväxttider och nödår lyckades Gustav III navigera skickligt, samtidigt som andra regenter i Europa drabbades betydligt hårdare.Och så uppmärksammar vi 400-årsdagen av den spanska galeonen Atochas undergång, och fyndet av hennes last som räknas som den värdefullaste i marinarkeologins historia.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/6b8a3VEBTu4bnyt7JNv2p6"
+                        "spotify": "https://open.spotify.com/episode/3ImQwVrE6XBcb44zbZUk9x"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/6b8a3VEBTu4bnyt7JNv2p6",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF09, Papa Don’t Leech, the sixteenth episode of Season Nineteen. They talk about Lurleen, murderous Homer, and deadbeat dads. Support us on Patreon! Listener Question of the Week: What one-off guest character would you bring back?",
-                    "id": "6b8a3VEBTu4bnyt7JNv2p6",
+                    "href": "https://api.spotify.com/v1/episodes/3ImQwVrE6XBcb44zbZUk9x",
+                    "html_description": "<p>Sverige hade kunnat bli symbolen för frihet, jämlikhet och broderskap om det inte varit för Gustav III:s statskupp för 250 år sedan. Hör om den och om klimatkrisen 1770 som pågick samtidigt.</p> <p>För 250 år sedan ställdes Sverige på ända. De demokratiska tendenser som börjat spira under Frihetstiden slog i ett slag sönder av Gustav III under hans statskupp. Vetenskapsradion Historia tar med sig historikern Jonas Nordin till Stockholms slott för att ta reda på hur kungen lyckades med kuppen och vilka politiska konsekvenser den fick för Sverige. Och vad som hade hänt om kuppen misslyckats?</p><p>Dessutom lyfter historikern Dominik Collet upp den allvarliga klimatkrisen under 1770-talet som en okänd anledning till att statskuppen lyckades. I missväxttider och nödår lyckades Gustav III navigera skickligt, samtidigt som andra regenter i Europa drabbades betydligt hårdare.</p><p>Och så uppmärksammar vi 400-årsdagen av den spanska galeonen Atochas undergång, och fyndet av hennes last som räknas som den värdefullaste i marinarkeologins historia.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "3ImQwVrE6XBcb44zbZUk9x",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a3fefd4e69b1bcbcbb67905a5",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f3fefd4e69b1bcbcbb67905a5",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d3fefd4e69b1bcbcbb67905a5",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "419 – Papa Don’t Leech",
-                    "release_date": "2022-05-23",
+                    "name": "Gustav III:s statskupp",
+                    "release_date": "2022-09-06",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:6b8a3VEBTu4bnyt7JNv2p6"
+                    "uri": "spotify:episode:3ImQwVrE6XBcb44zbZUk9x"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b75357e3597023fe91db307d2bb7a73b007be151",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF08, Smoke on the Daughter, the fifteenth episode of Season Nineteen. Support us on Patreon! Listener Question of the Week: What is your favorite fictional animal character?",
-                    "duration_ms": 5874123,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/7831162321c2f6e2179dc18e509518437b5a6535",
+                    "description": "Hör Vetenskapsradion Historia live från Tantolunden där Panelen och Tobias Svanelid diskuterar historiska val och forntida demokrati, men också sjunger om Tantobommen och diskuterar mammutrumpor. Vetenskapsradion Historia sänder live ifrån Ekermanska malmgården på Södermalm i Stockholm och bjuder in Historiepanelen med Kristina Ekero Eriksson, Jonathan Lindström och Annika Sandén för att diskutera historiska val och stockholmshistorier med Södermalmskoppling.Hör om vikingatida tingsplatser, om Torgny Lagman, om demokratiska säljägare och crossdressande 1600-talstjejer, och lyssna på musikalisk underhållning av The Apricots som spelar låtar med demokratihistorisk anknytning.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/37zETjNvuIZoNI0fEWdFdn"
+                        "spotify": "https://open.spotify.com/episode/0IUR1AOhKItNRh0f44GC9I"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/37zETjNvuIZoNI0fEWdFdn",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF08, Smoke on the Daughter, the fifteenth episode of Season Nineteen. Support us on Patreon! Listener Question of the Week: What is your favorite fictional animal character?",
-                    "id": "37zETjNvuIZoNI0fEWdFdn",
+                    "href": "https://api.spotify.com/v1/episodes/0IUR1AOhKItNRh0f44GC9I",
+                    "html_description": "<p>Hör Vetenskapsradion Historia live från Tantolunden där Panelen och Tobias Svanelid diskuterar historiska val och forntida demokrati, men också sjunger om Tantobommen och diskuterar mammutrumpor.</p> <p>Vetenskapsradion Historia sänder live ifrån Ekermanska malmgården på Södermalm i Stockholm och bjuder in Historiepanelen med Kristina Ekero Eriksson, Jonathan Lindström och Annika Sandén för att diskutera historiska val och stockholmshistorier med Södermalmskoppling.</p><p>Hör om vikingatida tingsplatser, om Torgny Lagman, om demokratiska säljägare och crossdressande 1600-talstjejer, och lyssna på musikalisk underhållning av The Apricots som spelar låtar med demokratihistorisk anknytning.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "0IUR1AOhKItNRh0f44GC9I",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a73f53bdd67eb2a3b793ee76b",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f73f53bdd67eb2a3b793ee76b",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d73f53bdd67eb2a3b793ee76b",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "418 – Smoke on the Daughter",
-                    "release_date": "2022-05-16",
+                    "name": "Livesändning om historiska svenska val",
+                    "release_date": "2022-08-30",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:37zETjNvuIZoNI0fEWdFdn"
+                    "uri": "spotify:episode:0IUR1AOhKItNRh0f44GC9I"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f06bb0fd8df0bab4d6ea932ce183d877cba86e6e",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF07, Dial N for Nerder, the fourteenth episode of Season Nineteen. They talk about Columbo, murder mysteries, and terrible, terrible B plots. Support us on Patreon! Listener Question of the Week: What’s your favorite fictional detective?",
-                    "duration_ms": 5677321,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/754f7f21b047547e940780e0f997948633a58044",
+                    "description": "I november 1942 vände andra världskriget och Peter Englund vill nu ta reda på hur vanliga människor upplevde denna tumultartade tid. Dessutom tar vi reda på vad Facebook gör med vår historiesyn. Hur kändes det att leva under en av de mörkaste och mest tumultartade månaderna under 1900-talet? Historikern Peter Englund har i aktuella boken Onda nätters drömmar samlat berättelserna från ett 40-tal helt vanliga människor som på olika sätt påverkades av krigets vändpunkt – frontsoldater, journalister, sexslavar, koncentrationslägerfångar och helt vanliga hemmafruar. Tobias Svanelid träffar författaren för att ta reda på vad dessa erfarenheter kan säga oss idag och vilken ny bild de ger av andra världskrigets vändpunkt.Dessutom uppmärksammar vi pinfärska forskningsfältet digital minnes- och historiekultur, där historiker och andra forskare nu vill ta reda på vad Facebook och andra sociala medier gör med våra minnen och vår historiekultur. Robin Ekelund vid Malmö universitet är en av få svenska forskare som fördjupat sig i ämnet.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/13G46dEM8suYGazAdauj3g"
+                        "spotify": "https://open.spotify.com/episode/0kHBMJv9ASbOkoEENdnvPY"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/13G46dEM8suYGazAdauj3g",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF07, Dial N for Nerder, the fourteenth episode of Season Nineteen. They talk about Columbo, murder mysteries, and terrible, terrible B plots. Support us on Patreon! Listener Question of the Week: What’s your favorite fictional detective?",
-                    "id": "13G46dEM8suYGazAdauj3g",
+                    "href": "https://api.spotify.com/v1/episodes/0kHBMJv9ASbOkoEENdnvPY",
+                    "html_description": "<p>I november 1942 vände andra världskriget och Peter Englund vill nu ta reda på hur vanliga människor upplevde denna tumultartade tid. Dessutom tar vi reda på vad Facebook gör med vår historiesyn.</p> <p>Hur kändes det att leva under en av de mörkaste och mest tumultartade månaderna under 1900-talet? Historikern Peter Englund har i aktuella boken Onda nätters drömmar samlat berättelserna från ett 40-tal helt vanliga människor som på olika sätt påverkades av krigets vändpunkt – frontsoldater, journalister, sexslavar, koncentrationslägerfångar och helt vanliga hemmafruar. Tobias Svanelid träffar författaren för att ta reda på vad dessa erfarenheter kan säga oss idag och vilken ny bild de ger av andra världskrigets vändpunkt.</p><p>Dessutom uppmärksammar vi pinfärska forskningsfältet digital minnes- och historiekultur, där historiker och andra forskare nu vill ta reda på vad Facebook och andra sociala medier gör med våra minnen och vår historiekultur. Robin Ekelund vid Malmö universitet är en av få svenska forskare som fördjupat sig i ämnet.</p>",
+                    "id": "0kHBMJv9ASbOkoEENdnvPY",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8aca8e4a7514e87017cf543816",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fca8e4a7514e87017cf543816",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dca8e4a7514e87017cf543816",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "417 – Dial N for Nerder",
-                    "release_date": "2022-05-09",
+                    "name": "November 1942 – världskrigets vändpunkt",
+                    "release_date": "2022-08-23",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:13G46dEM8suYGazAdauj3g"
+                    "uri": "spotify:episode:0kHBMJv9ASbOkoEENdnvPY"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/b0fde1455761b2cbb911063a82e8b8b8ceda9cde",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF06, The Debarted, the thirteenth episode of Season Nineteen. They talk about bad B plots, good pastiches, and enjoyable episodes. Support us on Patreon! Listener Question of the Week: What’s your favorite ending to a movie?",
-                    "duration_ms": 4630760,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/96d8d5f0caf2a80018b499cb26362e929321d165",
+                    "description": "Ta med dig en historiebok i hängmattan så blir sommaren både spännande och lärorik. Och om det regnar kanske ett historiskt brädspel kan funka som underhållning? Skandaler i societeten, mumiens förbannelse eller kolgruvor i Storbritannien kanske kan underhålla i hängmattan i sommar? Vetenskapsradion Historias Tobias Svanelid sammankallar Kristina Ekero Eriksson och Urban Björstadius för att tipsa om historiska böcker inför semestern, och så testar Spelpanelen två historiska brädspel med industrihistoriskt tema och delar ut betyg.Böcker och spel som nämns i programmet:Historiska kärlekspar av Sara GribergSveriges historia för släktforskare av Roger Axelsson, Carin Bergström, Carl Henrik Carlsson och Sofia LingDe kommer att vara annorlunda svenskar av Simon Sorgenfrei Jaquette Gyldenstolpe av Anna-Lena BergSvarta St Barthelemy av Fredrik ThomassonSveriges långa historia av Jonathan LindströmTusen år i Uppåkra av Dick HarrisonKlart skepp av Ann Pålsson (redaktör)Ruths garderob av Ingela BendtExtas i folkhemmet av Leonidas AretakisJakten på Tutankhamon av Bengt Fredriksson och Andreas PalmaerFurnace av Ivan LashinBrass Birmingham av Gavan Brown, Matt Tolman och Martin Wallace",
+                    "duration_ms": 2685000,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/10zCZJKgKEerI6edwYTWvR"
+                        "spotify": "https://open.spotify.com/episode/4PulPQRdLooLmCdKiEe9GV"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/10zCZJKgKEerI6edwYTWvR",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF06, The Debarted, the thirteenth episode of Season Nineteen. They talk about bad B plots, good pastiches, and enjoyable episodes. Support us on Patreon! Listener Question of the Week: What’s your favorite ending to a movie?",
-                    "id": "10zCZJKgKEerI6edwYTWvR",
+                    "href": "https://api.spotify.com/v1/episodes/4PulPQRdLooLmCdKiEe9GV",
+                    "html_description": "<p>Ta med dig en historiebok i hängmattan så blir sommaren både spännande och lärorik. Och om det regnar kanske ett historiskt brädspel kan funka som underhållning?</p> <p>Skandaler i societeten, mumiens förbannelse eller kolgruvor i Storbritannien kanske kan underhålla i hängmattan i sommar? Vetenskapsradion Historias Tobias Svanelid sammankallar Kristina Ekero Eriksson och Urban Björstadius för att tipsa om historiska böcker inför semestern, och så testar Spelpanelen två historiska brädspel med industrihistoriskt tema och delar ut betyg.</p><p>Böcker och spel som nämns i programmet:</p><p>Historiska kärlekspar av Sara Griberg</p><p>Sveriges historia för släktforskare av Roger Axelsson, Carin Bergström, Carl Henrik Carlsson och Sofia Ling</p><p>De kommer att vara annorlunda svenskar av Simon Sorgenfrei </p><p>Jaquette Gyldenstolpe av Anna-Lena Berg</p><p>Svarta St Barthelemy av Fredrik Thomasson</p><p>Sveriges långa historia av Jonathan Lindström</p><p>Tusen år i Uppåkra av Dick Harrison</p><p>Klart skepp av Ann Pålsson (redaktör)</p><p>Ruths garderob av Ingela Bendt</p><p>Extas i folkhemmet av Leonidas Aretakis</p><p>Jakten på Tutankhamon av Bengt Fredriksson och Andreas Palmaer</p><p>Furnace av Ivan Lashin</p><p>Brass Birmingham av Gavan Brown, Matt Tolman och Martin Wallace</p>",
+                    "id": "4PulPQRdLooLmCdKiEe9GV",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a41807911678c0b83537f2a99",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f41807911678c0b83537f2a99",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d41807911678c0b83537f2a99",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "416 – The Debarted",
-                    "release_date": "2022-05-02",
+                    "name": "Kärlek och industriromantik förgyller sommaren",
+                    "release_date": "2022-06-21",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:10zCZJKgKEerI6edwYTWvR"
+                    "uri": "spotify:episode:4PulPQRdLooLmCdKiEe9GV"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/e44ca9c05ee5bdab9f809a053b28050f6b768748",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF05, Love, Springfieldian Style, the twelfth episode of Season Nineteen. They talk about love, connecting stories, and filler. Support the show on Patreon! Listener Question of the Week: What’s your favorite romantic comedy?",
-                    "duration_ms": 4655665,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/536e38215bd49e90208d92e6b0b1198a450b4306",
+                    "description": "Hör om stridshingstar, fotbollskrig, 1200-talets Vietnamkrig och mycket annat i Vetenskapsradion Historias lyssnarfrågemarathon där Dick Harrison svarar på lyssnarnas egna frågor i ett helt program. Vad hände under Fotbollskriget 1969 och Körsbärskriget 1631 och varför bröt de ut? Följ med Vetenskapsradion Historia på Dick Harrison långlopp, årets lyssnarfrågemarathon där historieprofessorn besvarar lyssnarnas egna frågor. Denna gång berör samtliga frågor historiska krig med anledning av den pågående ryska invasionen av Ukraina.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/7BsvYKgXQlvqd3RmHEOuCx"
+                        "spotify": "https://open.spotify.com/episode/1m0Kagczdo04dXgvdWPuHu"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/7BsvYKgXQlvqd3RmHEOuCx",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF05, Love, Springfieldian Style, the twelfth episode of Season Nineteen. They talk about love, connecting stories, and filler. Support the show on Patreon! Listener Question of the Week: What’s your favorite romantic comedy?",
-                    "id": "7BsvYKgXQlvqd3RmHEOuCx",
+                    "href": "https://api.spotify.com/v1/episodes/1m0Kagczdo04dXgvdWPuHu",
+                    "html_description": "<p>Hör om stridshingstar, fotbollskrig, 1200-talets Vietnamkrig och mycket annat i Vetenskapsradion Historias lyssnarfrågemarathon där Dick Harrison svarar på lyssnarnas egna frågor i ett helt program.</p> <p>Vad hände under Fotbollskriget 1969 och Körsbärskriget 1631 och varför bröt de ut? Följ med Vetenskapsradion Historia på Dick Harrison långlopp, årets lyssnarfrågemarathon där historieprofessorn besvarar lyssnarnas egna frågor. Denna gång berör samtliga frågor historiska krig med anledning av den pågående ryska invasionen av Ukraina.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "1m0Kagczdo04dXgvdWPuHu",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a2e4f8d2a0f3b11bbe5c5e1e3",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f2e4f8d2a0f3b11bbe5c5e1e3",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d2e4f8d2a0f3b11bbe5c5e1e3",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "415 – Love, Springfieldian Style",
-                    "release_date": "2022-04-25",
+                    "name": "Lyssnarfrågemarathon med toyotakrig, fotbollskrig och körsbärskrig!",
+                    "release_date": "2022-06-14",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:7BsvYKgXQlvqd3RmHEOuCx"
+                    "uri": "spotify:episode:1m0Kagczdo04dXgvdWPuHu"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/a01f769652c5e52e24fac24b303899594c46c18f",
-                    "description": "Tonight, Matt and Robbie are joined by Andrew Bloom to discuss Episode KABF04, That 90’s Show, the eleventh episode of Season Nineteen. They talk about references, retcons, and reckoning with The Simpsons timeline. Andrew’s Review Support the show on Patreon! Listener Question of the Week: What’s the plot of your Simpsons retcon episode?",
-                    "duration_ms": 8427645,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/33009f4972a398f72798bd1ab652ee6ac17d888a",
+                    "description": "Från Kronans undergång utanför Öland till den stora segern vid Svensksund. Flottans historia har format riket. Den har skapat stormakten Sverige och skyddat landets handel. Nu fyller den 500 år. För femhundra år sedan ankrade ett antal krigsskepp upp i Slätbaken. Skeppen, som köpts på kredit från Lübeck, skulle komma att utgöra de första fartygen i den svenska flottan, och i Vetenskapsradion Historia berättar historikern Lars Ericson Wolke om flottans födelse och betydelse för Sveriges historia.Följ med till platserna för flottans största segrar och nederlag, till vattnen utanför Öland och till Finska viken, och hör om hur man nu planerar att fira jubiléet i en tid då flottans roll danas om igen.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/09F4uX1Bo6nh0ibfcScTZg"
+                        "spotify": "https://open.spotify.com/episode/5BzMNb6pNFzS3eUYYcdwfS"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/09F4uX1Bo6nh0ibfcScTZg",
-                    "html_description": "Tonight, Matt and Robbie are joined by Andrew Bloom to discuss Episode KABF04, That 90’s Show, the eleventh episode of Season Nineteen. They talk about references, retcons, and reckoning with The Simpsons timeline. Andrew’s Review Support the show on Patreon! Listener Question of the Week: What’s the plot of your Simpsons retcon episode?",
-                    "id": "09F4uX1Bo6nh0ibfcScTZg",
+                    "href": "https://api.spotify.com/v1/episodes/5BzMNb6pNFzS3eUYYcdwfS",
+                    "html_description": "<p>Från Kronans undergång utanför Öland till den stora segern vid Svensksund. Flottans historia har format riket. Den har skapat stormakten Sverige och skyddat landets handel. Nu fyller den 500 år.</p> <p>För femhundra år sedan ankrade ett antal krigsskepp upp i Slätbaken. Skeppen, som köpts på kredit från Lübeck, skulle komma att utgöra de första fartygen i den svenska flottan, och i Vetenskapsradion Historia berättar historikern Lars Ericson Wolke om flottans födelse och betydelse för Sveriges historia.</p><p>Följ med till platserna för flottans största segrar och nederlag, till vattnen utanför Öland och till Finska viken, och hör om hur man nu planerar att fira jubiléet i en tid då flottans roll danas om igen.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "5BzMNb6pNFzS3eUYYcdwfS",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a279214989153202ca5782448",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f279214989153202ca5782448",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d279214989153202ca5782448",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "414 – That 90’s Show (w Andrew Bloom)",
-                    "release_date": "2022-04-18",
+                    "name": "Flottan fyller 500",
+                    "release_date": "2022-06-07",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:09F4uX1Bo6nh0ibfcScTZg"
+                    "uri": "spotify:episode:5BzMNb6pNFzS3eUYYcdwfS"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/e94cf661b2b41b0725c72a5e42358db7a36c2ddf",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF03, E Pluribus Wiggum, the tenth episode of Season Nineteen. They talk about politics, Ralph Wiggum, and caring. Order Burial! Support the Show on Patreon! Listener Question of the Week: What Simpsons character would make the best President?",
-                    "duration_ms": 6736116,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/7c065061ed2c53b2f564d9e4625a311baaf9b526",
+                    "description": "Glöm den skäggige grottmannen och tänk dig istället en fingerfärdig och pratsam kulturvarelse med goda relationer med vår egen art. Det är författaren Rebecca Wragg Sykes budskap i aktuella Släktskap. Satte han på sig en kostym hade man knappt sett någon skillnad mellan neanderthalaren och oss själva. Vetenskapsradion Historia tar pulsen på den senaste forskningen om vår nära kusin som nu presenteras i aktuella boken Släktskap av arkeologen Rebecca Wragg Sykes. Med dagens vetenskapliga metoder kan en enda neanderthaltand avslöja vad personen åt, hur den reste, hur länge den ammades och hur den tillverkade sina verktyg, och all denna kunskap ger oss ny en helt ny bild av vår nära släkting. Glöm den barbariske grottmannen, och tänk dig istället en kulturellt utvecklad varelse som säkert hade nära samarbete med vår egen art, menar författaren.Och så tipsar Panelen om historiska sommaraktiviteter och lekar som kan förnöja oss och reder ut vilken roll barnen spelat i historien apropå aktuella säsongen av Stranger Things.Programledare är Tobias Svanelid.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/5reN7mii9N0QgU9qvWl8T2"
+                        "spotify": "https://open.spotify.com/episode/5TpImZuFku43lvR0JyMvjO"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/5reN7mii9N0QgU9qvWl8T2",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF03, E Pluribus Wiggum, the tenth episode of Season Nineteen. They talk about politics, Ralph Wiggum, and caring. Order Burial! Support the Show on Patreon! Listener Question of the Week: What Simpsons character would make the best President?",
-                    "id": "5reN7mii9N0QgU9qvWl8T2",
+                    "href": "https://api.spotify.com/v1/episodes/5TpImZuFku43lvR0JyMvjO",
+                    "html_description": "<p>Glöm den skäggige grottmannen och tänk dig istället en fingerfärdig och pratsam kulturvarelse med goda relationer med vår egen art. Det är författaren Rebecca Wragg Sykes budskap i aktuella Släktskap.</p> <p>Satte han på sig en kostym hade man knappt sett någon skillnad mellan neanderthalaren och oss själva. Vetenskapsradion Historia tar pulsen på den senaste forskningen om vår nära kusin som nu presenteras i aktuella boken Släktskap av arkeologen Rebecca Wragg Sykes. Med dagens vetenskapliga metoder kan en enda neanderthaltand avslöja vad personen åt, hur den reste, hur länge den ammades och hur den tillverkade sina verktyg, och all denna kunskap ger oss ny en helt ny bild av vår nära släkting. Glöm den barbariske grottmannen, och tänk dig istället en kulturellt utvecklad varelse som säkert hade nära samarbete med vår egen art, menar författaren.</p><p>Och så tipsar Panelen om historiska sommaraktiviteter och lekar som kan förnöja oss och reder ut vilken roll barnen spelat i historien apropå aktuella säsongen av Stranger Things.</p><p>Programledare är Tobias Svanelid.</p>",
+                    "id": "5TpImZuFku43lvR0JyMvjO",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8ac301f28bb3c12e16024f411a",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1fc301f28bb3c12e16024f411a",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68dc301f28bb3c12e16024f411a",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "413 – E Pluribus Wiggum",
-                    "release_date": "2022-04-11",
+                    "name": "Hemlighetsfulla neanderthalaren i rampljuset",
+                    "release_date": "2022-05-31",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:5reN7mii9N0QgU9qvWl8T2"
+                    "uri": "spotify:episode:5TpImZuFku43lvR0JyMvjO"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/f34342f5df38db60a36bbca9323a79a68c57d4fb",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF02, Eternal Moonshine of the Simpson Mind, the ninth episode of Season Nineteen. They talk about mysteries, Patty & Selma, and contrivances. Pre-Order Burial! Support The Simpsons Show on Patreon! Listener Question of the Week: What’s your favorite drink?",
-                    "duration_ms": 5700961,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/c82a5f41619e3d20b80df210b39c2b7e1bb0a97b",
+                    "description": "Följ med Tobias Svanelid på en vandring längs Birger Jarlsgatan, startpunkten för den muslimska invandringen i Sverige. Och hör om korstågens betydelse för islams expansion. Stockholmsutställningen 1897 fick besök av den ryske muslimen Ebrahim Umerkajeff, en pälshandlare som hittade kärleken i Sverige och blev kvar. Om honom och de andra tidiga muslimska invandrarna som fick svenskt medborgarskap handlar religionsvetaren Simon Sorgenfreis aktuella bok De kommer att vara annorlunda svenskar. Tobias Svanelid tar med författaren på en vandring längs Birger Jarlsgatan i Stockholm, platsen för de första svenska muslimernas företag och startpunkten för den utveckling som idag gjort Sverige till ett av världens mest mångkulturella länder.Dessutom svarar Dick Harrison på en lyssnarfråga om vad som hade hänt med Europas kristna befolkning om påven Urban II aldrig dragit igång korstågen.",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/5qIyxVAq36uDTElceC9U5O"
+                        "spotify": "https://open.spotify.com/episode/29pGMHLbL8MEOlixPUrom3"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/5qIyxVAq36uDTElceC9U5O",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF02, Eternal Moonshine of the Simpson Mind, the ninth episode of Season Nineteen. They talk about mysteries, Patty &amp; Selma, and contrivances. Pre-Order Burial! Support The Simpsons Show on Patreon! Listener Question of the Week: What’s your favorite drink?",
-                    "id": "5qIyxVAq36uDTElceC9U5O",
+                    "href": "https://api.spotify.com/v1/episodes/29pGMHLbL8MEOlixPUrom3",
+                    "html_description": "<p>Följ med Tobias Svanelid på en vandring längs Birger Jarlsgatan, startpunkten för den muslimska invandringen i Sverige. Och hör om korstågens betydelse för islams expansion.</p> <p>Stockholmsutställningen 1897 fick besök av den ryske muslimen Ebrahim Umerkajeff, en pälshandlare som hittade kärleken i Sverige och blev kvar. Om honom och de andra tidiga muslimska invandrarna som fick svenskt medborgarskap handlar religionsvetaren Simon Sorgenfreis aktuella bok De kommer att vara annorlunda svenskar. Tobias Svanelid tar med författaren på en vandring längs Birger Jarlsgatan i Stockholm, platsen för de första svenska muslimernas företag och startpunkten för den utveckling som idag gjort Sverige till ett av världens mest mångkulturella länder.</p><p>Dessutom svarar Dick Harrison på en lyssnarfråga om vad som hade hänt med Europas kristna befolkning om påven Urban II aldrig dragit igång korstågen.</p>",
+                    "id": "29pGMHLbL8MEOlixPUrom3",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a83d4c56598da1efc5bbb98cc",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f83d4c56598da1efc5bbb98cc",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d83d4c56598da1efc5bbb98cc",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "412 – Eternal Moonshine of the Simpson Mind",
-                    "release_date": "2022-04-04",
+                    "name": "Sveriges första muslimer",
+                    "release_date": "2022-05-24",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:5qIyxVAq36uDTElceC9U5O"
+                    "uri": "spotify:episode:29pGMHLbL8MEOlixPUrom3"
                 },
                 {
-                    "audio_preview_url": "https://p.scdn.co/mp3-preview/2fa02c266275c2258dbb5642c5159dd77490e164",
-                    "description": "Tonight, Matt and Robbie discuss Episode KABF01, Funeral for a Fiend, the eighth episode of Season Nineteen. They talk about Sideshow Bob, goodwill, and layer after layer of absolute nonsense. Pre-Order Burial! Support us on Patreon! Listener Question of the Week: What’s your favorite mystery film?",
-                    "duration_ms": 5786517,
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/769eb5ee90c24ccdaa5ede9cd022fcb125a6f6d8",
+                    "description": "Ormen Friskes undergång på Nordsjön 1950 är en tragedi i Kalla krigets skugga. Nu lyfts berättelsen fram och frågetecknen rätas ut. Dessutom undersöker vi tjusningen med att bygga gamla träbåtar. Sommaren 1950 gick vikingaskeppet Ormen Friske under i Nordsjöns stormiga vågor. 15 man följde henne i djupet, och i Vetenskapsradion Historia undersöker vi den gripande och märkliga händelsen, en fartygskatastrof och en nationell tragedi i Kalla krigets skugga. Jack Werner är aktuell med boken Ormen Friske och berättar om människorna bakom frisksportprojektet att återskapa ett vikingaskepp och det misslyckade försöket att segla det ut i Europa.Dessutom besöker vi skeppsbyggarskolan på Skeppsholmen i Stockholm, där återskapade galeasen Förlig Vind nu tar form. Nyligen utsågs det traditionella nordiska skeppsbyggeriet till ett immateriellt världsarv, men vad är det egentligen som lockar med att återskapa gamla träfartyg?Programledare är Tobias Svanelid. ",
+                    "duration_ms": 2685024,
                     "explicit": false,
                     "external_urls": {
-                        "spotify": "https://open.spotify.com/episode/6xBvS4qd2K39a1p1C26tsD"
+                        "spotify": "https://open.spotify.com/episode/5hWBrfMZFNNzwpJuRlqqzy"
                     },
-                    "href": "https://api.spotify.com/v1/episodes/6xBvS4qd2K39a1p1C26tsD",
-                    "html_description": "Tonight, Matt and Robbie discuss Episode KABF01, Funeral for a Fiend, the eighth episode of Season Nineteen. They talk about Sideshow Bob, goodwill, and layer after layer of absolute nonsense. Pre-Order Burial! Support us on Patreon! Listener Question of the Week: What’s your favorite mystery film?",
-                    "id": "6xBvS4qd2K39a1p1C26tsD",
+                    "href": "https://api.spotify.com/v1/episodes/5hWBrfMZFNNzwpJuRlqqzy",
+                    "html_description": "<p>Ormen Friskes undergång på Nordsjön 1950 är en tragedi i Kalla krigets skugga. Nu lyfts berättelsen fram och frågetecknen rätas ut. Dessutom undersöker vi tjusningen med att bygga gamla träbåtar.</p> <p>Sommaren 1950 gick vikingaskeppet Ormen Friske under i Nordsjöns stormiga vågor. 15 man följde henne i djupet, och i Vetenskapsradion Historia undersöker vi den gripande och märkliga händelsen, en fartygskatastrof och en nationell tragedi i Kalla krigets skugga. Jack Werner är aktuell med boken Ormen Friske och berättar om människorna bakom frisksportprojektet att återskapa ett vikingaskepp och det misslyckade försöket att segla det ut i Europa.</p><p>Dessutom besöker vi skeppsbyggarskolan på Skeppsholmen i Stockholm, där återskapade galeasen Förlig Vind nu tar form. Nyligen utsågs det traditionella nordiska skeppsbyggeriet till ett immateriellt världsarv, men vad är det egentligen som lockar med att återskapa gamla träfartyg?</p><p>Programledare är Tobias Svanelid.</p><p> </p>",
+                    "id": "5hWBrfMZFNNzwpJuRlqqzy",
                     "images": [
                         {
                             "height": 640,
-                            "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                            "url": "https://i.scdn.co/image/ab6765630000ba8a78e0a3c92b4d358251aacd1f",
                             "width": 640
                         },
                         {
                             "height": 300,
-                            "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                            "url": "https://i.scdn.co/image/ab67656300005f1f78e0a3c92b4d358251aacd1f",
                             "width": 300
                         },
                         {
                             "height": 64,
-                            "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                            "url": "https://i.scdn.co/image/ab6765630000f68d78e0a3c92b4d358251aacd1f",
                             "width": 64
                         }
                     ],
                     "is_externally_hosted": false,
                     "is_playable": true,
-                    "language": "en-US",
+                    "language": "sv",
                     "languages": [
-                        "en-US"
+                        "sv"
                     ],
-                    "name": "411 – Funeral for a Fiend",
-                    "release_date": "2022-03-28",
+                    "name": "Kalla krigets vikingakatastrof",
+                    "release_date": "2022-05-17",
                     "release_date_precision": "day",
                     "type": "episode",
-                    "uri": "spotify:episode:6xBvS4qd2K39a1p1C26tsD"
+                    "uri": "spotify:episode:5hWBrfMZFNNzwpJuRlqqzy"
                 }
             ],
             "limit": 50,
-            "next": "https://api.spotify.com/v1/shows/4ZbloPxqlAqHbbP4EnivIB/episodes?offset=50&limit=50&market=GB",
+            "next": "https://api.spotify.com/v1/shows/38bS44xjbVVZ3No3ByF1dJ/episodes?offset=50&limit=50&market=GB",
             "offset": 0,
             "previous": null,
-            "total": 300
+            "total": 500
         },
         "explicit": false,
         "external_urls": {
-            "spotify": "https://open.spotify.com/show/4ZbloPxqlAqHbbP4EnivIB"
+            "spotify": "https://open.spotify.com/show/38bS44xjbVVZ3No3ByF1dJ"
         },
-        "href": "https://api.spotify.com/v1/shows/4ZbloPxqlAqHbbP4EnivIB",
-        "html_description": "A podcast looking back at The Simpsons, episode by episode, discussing and analyzing its importance, history, and greatness.",
-        "id": "4ZbloPxqlAqHbbP4EnivIB",
+        "href": "https://api.spotify.com/v1/shows/38bS44xjbVVZ3No3ByF1dJ",
+        "html_description": "Vi är där historien är.<br/>Ansvarig utgivare: Nina Glans",
+        "id": "38bS44xjbVVZ3No3ByF1dJ",
         "images": [
             {
                 "height": 640,
-                "url": "https://i.scdn.co/image/5dc7540613c82103d1445e54fa66e52710dfcde2",
+                "url": "https://i.scdn.co/image/84bc7407c7a61e805284314bef8b9ed5a7c31426",
                 "width": 640
             },
             {
                 "height": 300,
-                "url": "https://i.scdn.co/image/6cf91224bd8b08b19a02090df8559a6c76416d07",
+                "url": "https://i.scdn.co/image/4b89f866aa625cf02f98f80b968da52b65944bf2",
                 "width": 300
             },
             {
                 "height": 64,
-                "url": "https://i.scdn.co/image/d2696a8fd331c62cad28d7d38e463e96691e7a18",
+                "url": "https://i.scdn.co/image/cc1e47c7e3e5a169d2352e81dc1a681ac7bbc0bd",
                 "width": 64
             }
         ],
         "is_externally_hosted": false,
         "languages": [
-            "en"
+            "sv"
         ],
         "media_type": "audio",
-        "name": "The Simpsons Show",
-        "publisher": "The Simpsons Show",
-        "total_episodes": 300,
+        "name": "Vetenskapsradion Historia",
+        "publisher": "Sveriges Radio",
+        "total_episodes": 500,
         "type": "show",
-        "uri": "spotify:show:4ZbloPxqlAqHbbP4EnivIB"
+        "uri": "spotify:show:38bS44xjbVVZ3No3ByF1dJ"
     };
 }


### PR DESCRIPTION
Fix failing tests and improve real user account testing

# Problem

- Tests are failing when running CurrentUserEndpoints.test.ts using my personal account
- Test playlists are not cleaned up
- `validEpisode` is out of date
- `validShow` no longer exists

# Solution

- Choose an artist id, album id, and audiobook id before running the tests
- Check if these ids are followed/saved before running the tests, and restore their state when the tests are complete
- Follow/save these ids before running the tests for consistent results
- Unfollow any playlists created during the tests
- Ignore `total_episodes` in EpisodeEndpoints.test.ts
- Update `validShow` to a valid show

# Result

- More generic tests when using a random real user account
- All created playlists during CurrentUserEndpoints.test.ts are removed
- All tests pass