### PR TITLE
Update Track types

### DIFF
--- a/src/endpoints/AlbumsEndpoints.ts
+++ b/src/endpoints/AlbumsEndpoints.ts
@@ -1,4 +1,4 @@
-import type { Market, AlbumWithTracks, Albums, MaxInt, Page, Track } from '../types.js';
+import type { Market, AlbumWithTracks, Albums, MaxInt, Page, SimplifiedTrack } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class AlbumsEndpoints extends EndpointsBase {
@@ -20,6 +20,6 @@ export default class AlbumsEndpoints extends EndpointsBase {
 
     public tracks(albumId: string, market?: Market, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ market, limit, offset });
-        return this.getRequest<Page<Track>>(`albums/${albumId}/tracks${params}`);
+        return this.getRequest<Page<SimplifiedTrack>>(`albums/${albumId}/tracks${params}`);
     }
 }

--- a/src/endpoints/TracksEndpoints.ts
+++ b/src/endpoints/TracksEndpoints.ts
@@ -1,14 +1,14 @@
-import type { Market, TrackWithAlbum, Tracks, AudioFeatures, AudioFeaturesCollection, AudioAnalysis } from '../types.js';
+import type { Market, Track, Tracks, AudioFeatures, AudioFeaturesCollection, AudioAnalysis } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class TracksEndpoints extends EndpointsBase {
 
-    public get(id: string, market?: Market): Promise<TrackWithAlbum>
-    public get(ids: string[], market?: Market): Promise<TrackWithAlbum[]>
+    public get(id: string, market?: Market): Promise<Track>
+    public get(ids: string[], market?: Market): Promise<Track[]>
     public async get(idOrIds: string | string[], market?: Market) {
         if (typeof idOrIds === 'string') {
             const params = this.paramsFor({ market });
-            return this.getRequest<TrackWithAlbum>(`tracks/${idOrIds}${params}`);
+            return this.getRequest<Track>(`tracks/${idOrIds}${params}`);
         }
 
         const params = this.paramsFor({ ids: idOrIds, market });

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export interface SavedAlbum {
 }
 
 export interface AlbumWithTracks extends Album {
-    tracks: Page<Track>
+    tracks: Page<SimplifiedTrack>
 }
 
 export interface Albums {
@@ -139,7 +139,7 @@ export interface PlaylistedTrack {
     added_by: AddedBy
     is_local: boolean
     primary_color: any
-    track: TrackWithAlbum
+    track: Track
 }
 
 export interface AddedBy {
@@ -150,24 +150,31 @@ export interface AddedBy {
     uri: string
 }
 
-export interface Track {
+export interface LinkedFrom {
+    external_urls: ExternalUrls
+    href: string
+    id: string
+    type: string
+    uri: string
+}
+
+export interface SimplifiedTrack {
     artists: ArtistReference[]
     available_markets: string[]
     disc_number: number
     duration_ms: number
     explicit: boolean
     external_urls: ExternalUrls
-    external_ids: ExternalIds
     href: string
     id: string
     is_local: boolean
-    popularity: number
     name: string
     preview_url: string
     track_number: number
     type: string
     uri: string
-
+    is_playable?: boolean
+    linked_from?: LinkedFrom
     restrictions?: Restrictions
 }
 
@@ -182,12 +189,14 @@ export interface ExternalIds {
     upc: string
 }
 
-export interface TrackWithAlbum extends Track {
+export interface Track extends SimplifiedTrack {
     album: Album
+    external_ids: ExternalIds
+    popularity: number
 }
 
 export interface Tracks {
-    tracks: TrackWithAlbum[]
+    tracks: Track[]
 }
 
 export interface ArtistReference {

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,7 +169,7 @@ export interface SimplifiedTrack {
     id: string
     is_local: boolean
     name: string
-    preview_url: string
+    preview_url: string | null
     track_number: number
     type: string
     uri: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,7 +139,7 @@ export interface PlaylistedTrack {
     added_by: AddedBy
     is_local: boolean
     primary_color: any
-    track: Track
+    track: Track | Episode
 }
 
 export interface AddedBy {


### PR DESCRIPTION
Update Track types and fix inaccuracies

# Problem

- `TrackWithAlbum` is missing some properties
- Some properties are using type `Track` instead of `TrackWithAlbum`
- `TrackWithAlbum` is not an intuitive name for the GET `/tracks/{id}` response type
  - Additionally, the Web API uses `Track` and `SimplifiedTrack` as the object names - see [`tracks` here](https://developer.spotify.com/documentation/web-api/reference/get-several-tracks) or [`items` here](https://developer.spotify.com/documentation/web-api/reference/get-an-albums-tracks)
  - Likely the cause of #7 

# Solution

Fix all inaccuracies

Note that some instances of `Track` have not been updated since they should have already been `TrackWithAlbum`, but `TrackWithAlbum` is now called `Track`