### PR TITLE
Update Album types

### DIFF
--- a/src/endpoints/AlbumsEndpoints.ts
+++ b/src/endpoints/AlbumsEndpoints.ts
@@ -1,14 +1,14 @@
-import type { Market, AlbumWithTracks, Albums, MaxInt, Page, Track } from '../types.js';
+import type { Market, Album, Albums, MaxInt, Page, Track } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class AlbumsEndpoints extends EndpointsBase {
 
-    public async get(id: string, market?: Market): Promise<AlbumWithTracks>;
-    public async get(ids: string[], market?: Market): Promise<AlbumWithTracks[]>;
+    public async get(id: string, market?: Market): Promise<Album>;
+    public async get(ids: string[], market?: Market): Promise<Album[]>;
     public async get(idOrIds: string | string[], market?: Market) {
         if (typeof idOrIds === 'string') {
             const params = this.paramsFor({ market });
-            const album = await this.getRequest<AlbumWithTracks>(`albums/${idOrIds}${params}`);
+            const album = await this.getRequest<Album>(`albums/${idOrIds}${params}`);
             return album;
         }
 

--- a/src/endpoints/ArtistsEndpoints.ts
+++ b/src/endpoints/ArtistsEndpoints.ts
@@ -1,4 +1,4 @@
-import type { Artist, Artists, Market, MaxInt, Page, Album, TopTracksResult } from '../types.js';
+import type { Artist, Artists, Market, MaxInt, Page, SimplifiedAlbum, TopTracksResult } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class ArtistsEndpoints extends EndpointsBase {
@@ -19,7 +19,7 @@ export default class ArtistsEndpoints extends EndpointsBase {
 
     public albums(id: string, includeGroups?: string, market?: Market, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ "include_groups": includeGroups, market, limit, offset });
-        return this.getRequest<Page<Album>>(`artists/${id}/albums${params}`);
+        return this.getRequest<Page<SimplifiedAlbum>>(`artists/${id}/albums${params}`);
     }
 
     public topTracks(id: string, market: Market) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,10 +75,8 @@ export interface AccessToken {
     refresh_token: string;
 }
 
-export interface Album {
-    album_group: string
+interface AlbumBase {
     album_type: string
-    artists: ArtistReference[]
     available_markets: string[]
     copyrights: Copyright[]
     external_ids: ExternalIds
@@ -92,27 +90,33 @@ export interface Album {
     popularity: number
     release_date: string
     release_date_precision: string
+    restrictions?: Restrictions
     total_tracks: number
     type: string
     uri: string
+}
 
+export interface SimplifiedAlbum extends AlbumBase {
+    album_group: string
+    artists: ArtistReference[]
 }
 
 export interface SavedAlbum {
     added_at: string
-    album: AlbumWithTracks
+    album: Album
 }
 
-export interface AlbumWithTracks extends Album {
+export interface Album extends AlbumBase {
+    artists: Artist[]
     tracks: Page<Track>
 }
 
 export interface Albums {
-    albums: AlbumWithTracks[]
+    albums: Album[]
 }
 
 export interface NewReleases {
-    albums: Page<AlbumWithTracks>
+    albums: Page<SimplifiedAlbum>
 }
 
 export interface Copyright {
@@ -183,7 +187,7 @@ export interface ExternalIds {
 }
 
 export interface TrackWithAlbum extends Track {
-    album: Album
+    album: SimplifiedAlbum
 }
 
 export interface Tracks {
@@ -232,7 +236,7 @@ export interface ExternalUrls {
 export interface SearchResults {
     tracks: Page<Track>
     artists: Page<Artist>
-    albums: Page<Album>
+    albums: Page<SimplifiedAlbum>
     playlists: Page<Playlist>
     shows: Page<Show>
     episodes: Page<Episode>


### PR DESCRIPTION
Update Album types and fix inaccuracies

# Problem

- Use `Album`/`SimplifiedAlbum` naming convention (see #20)
- Album properties structure is not aligned with the API
  - `album_group` should only exist in `SimplifiedAlbum`
  - `artists` type should change based on Album object type
- New releases should use `SimplifiedAlbum` (see the [Web API](https://developer.spotify.com/documentation/web-api/reference/get-new-releases))

# Solution

Fix all inaccuracies