### PR TITLE
Update Playlist types

### DIFF
--- a/src/endpoints/BrowseEndpoints.ts
+++ b/src/endpoints/BrowseEndpoints.ts
@@ -1,4 +1,4 @@
-import type { CountryCodeA2, MaxInt, Categories, Category, NewReleases, PlaylistsWithTrackReferences } from '../types.js';
+import type { CountryCodeA2, MaxInt, Categories, Category, NewReleases, FeaturedPlaylists } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class BrowseEndpoints extends EndpointsBase {
@@ -22,11 +22,11 @@ export default class BrowseEndpoints extends EndpointsBase {
 
     public getFeaturedPlaylists(country?: CountryCodeA2, locale?: string, timestamp?: string, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ country, locale, timestamp, limit, offset });
-        return this.getRequest<PlaylistsWithTrackReferences>(`browse/featured-playlists${params}`);
+        return this.getRequest<FeaturedPlaylists>(`browse/featured-playlists${params}`);
     }
 
     public getPlaylistsForCategory(category_id: string, country?: CountryCodeA2, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ country, limit, offset });
-        return this.getRequest<PlaylistsWithTrackReferences>(`browse/categories/${category_id}/playlists${params}`);
+        return this.getRequest<FeaturedPlaylists>(`browse/categories/${category_id}/playlists${params}`);
     }
 }

--- a/src/endpoints/CurrentUserEndpoints.ts
+++ b/src/endpoints/CurrentUserEndpoints.ts
@@ -1,5 +1,5 @@
 import { SpotifyApi } from '../SpotifyApi.js';
-import type { User, Page, Artist, MaxInt, FollowedArtists, Market, SavedAlbum, Audiobook, PlaylistWithTrackReferences, SavedEpisode, SavedShow, SavedTrack } from '../types.js';
+import type { User, Page, Artist, MaxInt, FollowedArtists, Market, SavedAlbum, Audiobook, SimplifiedPlaylist, SavedEpisode, SavedShow, SavedTrack } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class CurrentUserEndpoints extends EndpointsBase {
@@ -114,7 +114,7 @@ class CurrentUserEpisodesEndpoints extends EndpointsBase {
 class CurrentUserPlaylistsEndpoints extends EndpointsBase {
     public playlists(limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ limit, offset });
-        return this.getRequest<Page<PlaylistWithTrackReferences>>(`me/playlists${params}`);
+        return this.getRequest<Page<SimplifiedPlaylist>>(`me/playlists${params}`);
     }
 
     public follow(playlist_id: string) {

--- a/src/endpoints/PlaylistsEndpoints.ts
+++ b/src/endpoints/PlaylistsEndpoints.ts
@@ -1,4 +1,4 @@
-import type { Market, PlaylistWithTracks, MaxInt, Page, Track, SnapshotReference, Image, PlaylistedTrack } from '../types.js';
+import type { Market, Playlist, MaxInt, Page, Track, SnapshotReference, Image, PlaylistedTrack } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class PlaylistsEndpoints extends EndpointsBase {
@@ -6,7 +6,7 @@ export default class PlaylistsEndpoints extends EndpointsBase {
     public getPlaylist(playlist_id: string, market?: Market, fields?: string, additional_types?: string) {
         // TODO: better support for fields
         const params = this.paramsFor({ market, fields, additional_types });
-        return this.getRequest<PlaylistWithTracks>(`playlists/${playlist_id}${params}`);
+        return this.getRequest<Playlist>(`playlists/${playlist_id}${params}`);
     }
 
     public getPlaylistItems(playlist_id: string, market?: Market, fields?: string, limit?: MaxInt<50>, offset?: number, additional_types?: string) {
@@ -41,11 +41,11 @@ export default class PlaylistsEndpoints extends EndpointsBase {
 
     public getUsersPlaylists(user_id: string, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ limit, offset });
-        return this.getRequest<Page<PlaylistWithTracks>>(`users/${user_id}/playlists${params}`);
+        return this.getRequest<Page<Playlist>>(`users/${user_id}/playlists${params}`);
     }
 
     public createPlaylist(user_id: string, request: CreatePlaylistRequest) {
-        return this.postRequest<PlaylistWithTracks>(`users/${user_id}/playlists`, request);
+        return this.postRequest<Playlist>(`users/${user_id}/playlists`, request);
     }
 
     public getPlaylistCoverImage(playlist_id: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,7 +233,7 @@ export interface SearchResults {
     tracks: Page<Track>
     artists: Page<Artist>
     albums: Page<Album>
-    playlists: Page<Playlist>
+    playlists: Page<PlaylistBase>
     shows: Page<Show>
     episodes: Page<Episode>
     audiobooks: Page<AudiobookWithChapters>
@@ -460,7 +460,7 @@ export interface SnapshotReference {
     snapshot_id: string
 }
 
-export interface Playlist {
+interface PlaylistBase {
     collaborative: boolean
     description: string
     external_urls: ExternalUrls
@@ -477,17 +477,17 @@ export interface Playlist {
     uri: string
 }
 
-export interface PlaylistWithTracks extends Playlist {
+export interface Playlist extends PlaylistBase {
     tracks: Page<PlaylistedTrack>
 }
 
-export interface PlaylistsWithTrackReferences {
+export interface FeaturedPlaylists {
     message: string;
-    playlists: Page<PlaylistWithTrackReferences>
+    playlists: Page<SimplifiedPlaylist>
 }
 
-export interface PlaylistWithTrackReferences extends Playlist {
-    tracks: TrackReference
+export interface SimplifiedPlaylist extends PlaylistBase {
+    tracks: TrackReference | null
 }
 
 export interface TrackReference {


### PR DESCRIPTION
Update Playlist types and fix inaccuracies

# Problem

- Use `Playlist`/`SimplifiedPlaylist` naming convention (see #20)
- `SimplifiedPlaylist` can have null `tracks` (see the `playlists.items.tracks` property in [this response](https://developer.spotify.com/documentation/web-api/reference/get-featured-playlists))
- `PlaylistsWithTrackReferences` should be named `FeaturedPlaylists` since it is only used with [`/browse/featured-playlists`](https://developer.spotify.com/documentation/web-api/reference/get-featured-playlists)

# Solution

Fix all inaccuracies