### PR TITLE
Update Chapter types

### DIFF
--- a/src/endpoints/AudiobooksEndpoints.ts
+++ b/src/endpoints/AudiobooksEndpoints.ts
@@ -1,4 +1,4 @@
-import type { Market, AudiobookWithChapters, Audiobooks, MaxInt, Page, Chapter } from '../types.js';
+import type { Market, AudiobookWithChapters, Audiobooks, MaxInt, Page, SimplifiedChapter } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class AudiobooksEndpoints extends EndpointsBase {
@@ -17,7 +17,7 @@ export default class AudiobooksEndpoints extends EndpointsBase {
 
     public getAudiobookChapters(id: string, market?: Market, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ market, limit, offset });
-        return this.getRequest<Page<Chapter>>(`audiobooks/${id}/chapters${params}`);
+        return this.getRequest<Page<SimplifiedChapter>>(`audiobooks/${id}/chapters${params}`);
     }
 
 }

--- a/src/endpoints/ChaptersEndpoints.ts
+++ b/src/endpoints/ChaptersEndpoints.ts
@@ -1,16 +1,16 @@
-import type { ChapterWithAudiobookAndRestrictions, Chapters } from '../types.js';
+import type { Chapter, Chapters } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 // These are mandatory, and the only supported market codes for the Chapters API
 export type ChapterMarket = "GB" | "US" | "IE" | "NZ" | "AU";
 
 export default class ChaptersEndpoints extends EndpointsBase {
-    public get(id: string, market: ChapterMarket): Promise<ChapterWithAudiobookAndRestrictions>;
-    public get(ids: string[], market: ChapterMarket): Promise<ChapterWithAudiobookAndRestrictions[]>;
+    public get(id: string, market: ChapterMarket): Promise<Chapter>;
+    public get(ids: string[], market: ChapterMarket): Promise<Chapter[]>;
     public async get(idOrIds: string | string[], market: ChapterMarket) {
         if (typeof idOrIds === 'string') {
             const params = this.paramsFor({ market });
-            return this.getRequest<ChapterWithAudiobookAndRestrictions>(`chapters/${idOrIds}${params}`);
+            return this.getRequest<Chapter>(`chapters/${idOrIds}${params}`);
         }
 
         // TODO: Only returns top 50, validate / pre-check here

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,7 +309,7 @@ export interface Audiobook {
 }
 
 export interface AudiobookWithChapters extends Audiobook {
-    chapters: Page<Chapter>
+    chapters: Page<SimplifiedChapter>
 }
 
 export interface Audiobooks {
@@ -353,7 +353,7 @@ export interface Author {
     name: string
 }
 
-export interface Chapter {
+export interface SimplifiedChapter {
     id: string
     description: string
     chapter_number: number
@@ -372,14 +372,15 @@ export interface Chapter {
     uri: string
     external_urls: ExternalUrls
     href: string
+    is_playable: boolean
+    restrictions?: Restrictions
 }
 
 export interface Chapters {
-    chapters: ChapterWithAudiobookAndRestrictions[];
+    chapters: Chapter[];
 }
 
-export interface ChapterWithAudiobookAndRestrictions extends Chapter {
-    restrictions?: Restrictions
+export interface Chapter extends SimplifiedChapter {
     audiobook: Audiobook
 }
 


### PR DESCRIPTION
Update Chapter types and fix inaccuracies

# Problem

- Use `Chapter`/`SimplifiedChapter` naming convention (see #20)
- `is_playable` and `restrictions` are missing from `SimplifiedChapter`

# Solution

Fix all inaccuracies