### PR TITLE
Add check for false booleans in paramsFor method

### DIFF
--- a/src/endpoints/EndpointsBase.test.ts
+++ b/src/endpoints/EndpointsBase.test.ts
@@ -12,6 +12,10 @@ class FakeEndPoints extends EndpointsBase {
     public functionWithStringArrayParam(ids: string[]) {
         return this.paramsFor({ ids });
     }
+
+    public functionWithBooleanParam(id: boolean) {
+        return this.paramsFor({ id });
+    }
 }
 
 describe("EndpointsBase", async () => {
@@ -33,6 +37,11 @@ describe("EndpointsBase", async () => {
     it("paramsFor can correctly url encode an array", () => {
         const result = sut.functionWithStringArrayParam(["one", "two"]);
         expect(result).toBe("?ids=one%2Ctwo");
+    });
+
+    it("paramsFor can correctly url encode a false boolean", () => {
+        const result = sut.functionWithBooleanParam(false);
+        expect(result).toBe("?id=false");
     });
 
 });

--- a/src/endpoints/EndpointsBase.ts
+++ b/src/endpoints/EndpointsBase.ts
@@ -23,7 +23,7 @@ export default class EndpointsBase {
     protected paramsFor(args: any) {
         const params = new URLSearchParams();
         for (let key of Object.getOwnPropertyNames(args)) {
-            if (args[key]) {
+            if (args[key] || (!args[key] && typeof args[key] === 'boolean')) {
                 params.append(key, args[key].toString());
             }
         }


### PR DESCRIPTION
Add an additional check for `paramsFor` function to account for false booleans.

### Problem

The `paramsFor` method would ignore false boolean values due to the truth check and cause errors as seen with some like the `togglePlaybackShuffle` method. 

### Solution

Added an extra check if the value is false and a boolean.
