### PR TITLE
Fix import

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run start
 Creating an instance of the SDK is easy, and can be done in a number of ways depending on which form of authentication you want to use.
 
 ```js
-import { SpotifyWebApi } from '@spotify/web-api-ts-sdk';
+import { SpotifyApi } from '@spotify/web-api-ts-sdk';
 
 // Choose one of the following:
 const sdk = SpotifyApi.withUserAuthorization("client-id", "https://localhost:3000", ["scope1", "scope2"]);


### PR DESCRIPTION
This pull request fixes a named import which should be `SpotifyApi` from https://github.com/spotify/spotify-web-api-ts-sdk/blob/5be5c9a/src/SpotifyApi.ts#L29, `SpotifyWebApi` doesn't seem to be exported.

The [blog post](https://developer.spotify.com/blog/2023-07-03-typescript-sdk) also references this import.