### PR TITLE
Export all types in index.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spotify/web-api-ts-sdk",
-  "version": "0.0.21",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spotify/web-api-ts-sdk",
-      "version": "0.0.21",
+      "version": "1.0.0",
       "license": "Apache",
       "devDependencies": {
         "@types/node": "^20.3.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,6 @@ import DefaultResponseDeserializer from "./serialization/DefaultResponseDeserial
 import { Scopes } from "./Scopes.js";
 import { emptyAccessToken } from "./auth/IAuthStrategy.js";
 
-import type {
-    SearchResults
-} from "./types.js";
-
-export * from "./types.js";
-
 export {
     SpotifyApi,
     AuthorizationCodeWithPKCEStrategy,
@@ -36,8 +30,9 @@ export {
     emptyAccessToken
 }
 
+export type * from "./types.js";
+
 export type {
     IAuthStrategy,
     ICacheStore,
-    SearchResults
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import type {
     SearchResults
 } from "./types.js";
 
+export * from "./types.js";
+
 export {
     SpotifyApi,
     AuthorizationCodeWithPKCEStrategy,


### PR DESCRIPTION
module-name: export all types from `types.ts` in `index.ts`

Problem

Resolves #33. The TypeScript types currently cannot be imported in a project using the SDK. This stops users from typing for example their state correctly. 

Solution

Export all types from `types.ts` in `index.ts` to allow users to import these types in their projects