### PR TITLE
readme: Add require statement in server side example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ These functions will work as usual, triggering a client side redirect to grant p
 
 *Server Side*
 ```js
+const { SpotifyApi } = require("@spotify/web-api-ts-sdk");
+
 const express = require('express');
 const bodyParser = require('body-parser'); 
 const app = express();


### PR DESCRIPTION
I'm not sure whether this is intentional or not, but there is no require statement in the example 'server-side' code with expressJS.

I figured it could be a good thing to add, since the example snippet does contain express' require statements. Maybe it could also be added to the client side snippet.

Also, the blog post does contain an example of mjs' import and CommonJS' require, but the readme doesn't. This could come handy here, maybe a mention of the code could be sufficient? Sometimes people overlook documentation, it could help people that will Ctrl-F "import" and "require' (talking by experience)