### PR TITLE
Check for Buffer in clientCredentialsStrategy

### DIFF
--- a/src/auth/ClientCredentialsStrategy.ts
+++ b/src/auth/ClientCredentialsStrategy.ts
@@ -36,12 +36,17 @@ export default class ClientCredentialsStrategy implements IAuthStrategy {
         } as any;
 
         const bodyAsString = Object.keys(options).map(key => key + '=' + options[key]).join('&');
+        const hasBuffer = typeof Buffer !== 'undefined';
+
+        const basicAuth = hasBuffer
+            ? Buffer.from(this.clientId + ':' + this.clientSecret).toString('base64')
+            : btoa(this.clientId + ':' + this.clientSecret);
 
         const result = await fetch("https://accounts.spotify.com/api/token", {
             method: 'POST',
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Authorization": 'Basic ' + (Buffer.from(this.clientId + ':' + this.clientSecret).toString('base64'))
+                "Authorization": `Basic ${basicAuth}`
             },
             body: bodyAsString
         });

--- a/src/auth/ClientCredentialsStrategy.ts
+++ b/src/auth/ClientCredentialsStrategy.ts
@@ -37,10 +37,11 @@ export default class ClientCredentialsStrategy implements IAuthStrategy {
 
         const bodyAsString = Object.keys(options).map(key => key + '=' + options[key]).join('&');
         const hasBuffer = typeof Buffer !== 'undefined';
+        const credentials = `${this.clientId}:${this.clientSecret}`;
 
         const basicAuth = hasBuffer
-            ? Buffer.from(this.clientId + ':' + this.clientSecret).toString('base64')
-            : btoa(this.clientId + ':' + this.clientSecret);
+            ? Buffer.from(credentials).toString('base64')
+            : btoa(credentials);
 
         const result = await fetch("https://accounts.spotify.com/api/token", {
             method: 'POST',


### PR DESCRIPTION
Fixes https://github.com/spotify/spotify-web-api-ts-sdk/issues/39

In AccessTokensHelpers.ts there is a check for a Buffer before using it. I've copied this logic to where Buffer is used in ClientCredentialsStrategy.ts. 