### PR TITLE
Extend topItems to include time_range as per @lukemansell 

### DIFF
--- a/src/endpoints/ArtistsEndpoints.ts
+++ b/src/endpoints/ArtistsEndpoints.ts
@@ -1,25 +1,45 @@
-import type { Artist, Artists, Market, MaxInt, Page, SimplifiedAlbum, TopTracksResult } from '../types.js';
-import EndpointsBase from './EndpointsBase.js';
+
+import type {
+    Artist,
+    Artists,
+    Market,
+    MaxInt,
+    Page,
+    SimplifiedAlbum,
+    TopTracksResult,
+} from "../types.js";
+import EndpointsBase from "./EndpointsBase.js";
 
 export default class ArtistsEndpoints extends EndpointsBase {
-
     public async get(id: string): Promise<Artist>;
     public async get(ids: string[]): Promise<Artist[]>;
     public async get(idOrIds: string | string[]) {
-        if (typeof idOrIds === 'string') {
+        if (typeof idOrIds === "string") {
             const artist = this.getRequest<Artist>(`artists/${idOrIds}`);
             return artist;
         }
 
         const params = this.paramsFor({ ids: idOrIds });
-        // TODO: only returns top 50, validate here
         const response = await this.getRequest<Artists>(`artists${params}`);
         return response.artists;
     }
 
-    public albums(id: string, includeGroups?: string, market?: Market, limit?: MaxInt<50>, offset?: number) {
-        const params = this.paramsFor({ "include_groups": includeGroups, market, limit, offset });
-        return this.getRequest<Page<SimplifiedAlbum>>(`artists/${id}/albums${params}`);
+    public albums(
+        id: string,
+        includeGroups?: string,
+        market?: Market,
+        limit?: MaxInt<50>,
+        offset?: number
+    ) {
+        const params = this.paramsFor({
+            include_groups: includeGroups,
+            market,
+            limit,
+            offset,
+        });
+        return this.getRequest<Page<SimplifiedAlbum>>(
+            `artists/${id}/albums${params}`
+        );
     }
 
     public topTracks(id: string, market: Market) {
@@ -27,11 +47,12 @@ export default class ArtistsEndpoints extends EndpointsBase {
         // otherwise you get a 400
 
         const params = this.paramsFor({ market });
-        return this.getRequest<TopTracksResult>(`artists/${id}/top-tracks${params}`);
+        return this.getRequest<TopTracksResult>(
+            `artists/${id}/top-tracks${params}`
+        );
     }
 
     public relatedArtists(id: string) {
         return this.getRequest<Artists>(`artists/${id}/related-artists`);
     }
-
 }

--- a/src/endpoints/CurrentUserEndpoints.test.ts
+++ b/src/endpoints/CurrentUserEndpoints.test.ts
@@ -93,7 +93,7 @@ describe("Integration: Users Endpoints (logged in user)", () => {
     });
 
     it("getUsersTopItems returns items for artists", async () => {
-        const result = await sut.currentUser.topItems("tracks");
+        const result = await sut.currentUser.topItems("artists");
 
         expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/artists");
         expect(result.limit).toBeGreaterThan(0);

--- a/src/endpoints/CurrentUserEndpoints.test.ts
+++ b/src/endpoints/CurrentUserEndpoints.test.ts
@@ -86,13 +86,27 @@ describe("Integration: Users Endpoints (logged in user)", () => {
     });
 
     it("getUsersTopItems returns items for tracks", async () => {
+        const result = await sut.currentUser.topItems("tracks");
+
+        expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/tracks");
+        expect(result.limit).toBeGreaterThan(0);
+    });
+
+    it("getUsersTopItems returns items for artists", async () => {
+        const result = await sut.currentUser.topItems("tracks");
+
+        expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/artists");
+        expect(result.limit).toBeGreaterThan(0);
+    });
+
+    it("getUsersTopItems returns items for tracks and time_range", async () => {
         const result = await sut.currentUser.topItems("tracks", 'medium_term');
 
         expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/tracks?time_range=medium_term");
         expect(result.limit).toBeGreaterThan(0);
     });
 
-    it("getUsersTopItems returns items for artists", async () => {
+    it("getUsersTopItems returns items for artists and time_range", async () => {
         const result = await sut.currentUser.topItems("artists", 'short_term');
 
         expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/artists?time_range=short_term");

--- a/src/endpoints/CurrentUserEndpoints.test.ts
+++ b/src/endpoints/CurrentUserEndpoints.test.ts
@@ -85,10 +85,17 @@ describe("Integration: Users Endpoints (logged in user)", () => {
         expect(result.id.length).toBeGreaterThan(0);
     });
 
-    it("getUsersTopItems returns items", async () => {
-        const result = await sut.currentUser.topItems("artists");
+    it("getUsersTopItems returns items for tracks", async () => {
+        const result = await sut.currentUser.topItems("tracks", 'medium_term');
 
-        expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/artists");
+        expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/tracks?time_range=medium_term");
+        expect(result.limit).toBeGreaterThan(0);
+    });
+
+    it("getUsersTopItems returns items for artists", async () => {
+        const result = await sut.currentUser.topItems("artists", 'short_term');
+
+        expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/top/artists?time_range=short_term");
         expect(result.limit).toBeGreaterThan(0);
     });
 

--- a/src/endpoints/CurrentUserEndpoints.ts
+++ b/src/endpoints/CurrentUserEndpoints.ts
@@ -25,6 +25,10 @@ export default class CurrentUserEndpoints extends EndpointsBase {
         return this.getRequest<User>('me');
     }
 
+    public topItems(type: "artists" | "tracks") {
+        return this.getRequest<Page<Artist>>(`me/top/${type}`);
+    }
+
     public topItems(type: "artists" | "tracks", timerange: 'short_term' | 'medium_term' | 'long_term') {
         return this.getRequest<Page<Artist>>(`me/top/${type}?time_range=${timerange}`);
     }

--- a/src/endpoints/CurrentUserEndpoints.ts
+++ b/src/endpoints/CurrentUserEndpoints.ts
@@ -25,12 +25,14 @@ export default class CurrentUserEndpoints extends EndpointsBase {
         return this.getRequest<User>('me');
     }
 
-    public topItems(type: "artists" | "tracks") {
-        return this.getRequest<Page<Artist>>(`me/top/${type}`);
-    }
-
-    public topItems(type: "artists" | "tracks", timerange: 'short_term' | 'medium_term' | 'long_term') {
-        return this.getRequest<Page<Artist>>(`me/top/${type}?time_range=${timerange}`);
+    public topItems(type: "artists" | "tracks"): Promise<Page<Artist>>;
+    public topItems(type: "artists" | "tracks", time_range?: 'short_term' | 'medium_term' | 'long_term'): Promise<Page<Artist>>;
+    public topItems(type: "artists" | "tracks", time_range?: 'short_term' | 'medium_term' | 'long_term') {
+        if (time_range) {
+            return this.getRequest<Page<Artist>>(`me/top/${type}?time_range=${time_range}`);
+        } else {
+            return this.getRequest<Page<Artist>>(`me/top/${type}`);
+        }
     }
 
     public followedArtists(after?: string, limit?: MaxInt<50>) {

--- a/src/endpoints/CurrentUserEndpoints.ts
+++ b/src/endpoints/CurrentUserEndpoints.ts
@@ -25,8 +25,8 @@ export default class CurrentUserEndpoints extends EndpointsBase {
         return this.getRequest<User>('me');
     }
 
-    public topItems(type: "artists" | "tracks") {
-        return this.getRequest<Page<Artist>>(`me/top/${type}`);
+    public topItems(type: "artists" | "tracks", timerange: 'short_term' | 'medium_term' | 'long_term') {
+        return this.getRequest<Page<Artist>>(`me/top/${type}?time_range=${timerange}`);
     }
 
     public followedArtists(after?: string, limit?: MaxInt<50>) {


### PR DESCRIPTION
Expands topItems to include time_range option (short_term, medium_term, long_term)

Problem
Currently you can not manipulate the time_range option on the topItems endpoint.

Solution
Expand the topItems endpoint to include the time_range option as documented here: https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks

Credit @lukemansell