### PR TITLE
Fix emptyAccessToken comparison in performUserAuthorization

### DIFF
--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -201,8 +201,6 @@ export class SpotifyApi {
     public static async performUserAuthorization(clientId: string, redirectUri: string, scopes: string[], onAuthorization: (token: AccessToken) => Promise<void>, config?: SdkOptions): Promise<void>;
 
     public static async performUserAuthorization(clientId: string, redirectUri: string, scopes: string[], onAuthorizationOrUrl: ((token: AccessToken) => Promise<void>) | string, config?: SdkOptions): Promise<void> {
-        scopes = scopes || [];
-
         const strategy = new AuthorizationCodeWithPKCEStrategy(clientId, redirectUri, scopes);
         const client = new SpotifyApi(strategy, config);
         const accessToken = await client.authenticationStrategy.getOrCreateAccessToken();

--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -204,7 +204,8 @@ export class SpotifyApi {
         const strategy = new AuthorizationCodeWithPKCEStrategy(clientId, redirectUri, scopes);
         const client = new SpotifyApi(strategy, config);
         const accessToken = await client.authenticationStrategy.getOrCreateAccessToken();
-        if (accessToken == emptyAccessToken) {
+
+        if (JSON.stringify({ ...accessToken, expires: 0 }) === JSON.stringify(emptyAccessToken)) {
             return; // Redirect code path, do nothing.
         }
 

--- a/src/auth/AuthorizationCodeWithPKCEStrategy.ts
+++ b/src/auth/AuthorizationCodeWithPKCEStrategy.ts
@@ -87,7 +87,6 @@ export default class AuthorizationCodeWithPKCEStrategy implements IAuthStrategy 
     }
 
     protected async generateRedirectUrlForUser(scopes: string[], challenge: string) {
-        scopes = scopes ?? [];
         const scope = scopes.join(' ');
 
         const params = new URLSearchParams();

--- a/src/auth/IAuthStrategy.ts
+++ b/src/auth/IAuthStrategy.ts
@@ -1,6 +1,6 @@
 import type { AccessToken, SdkConfiguration } from "../types.js";
 
-export const emptyAccessToken: AccessToken = { access_token: "", token_type: "", expires_in: 0, refresh_token: "" };
+export const emptyAccessToken: AccessToken = { access_token: "", token_type: "", expires_in: 0, refresh_token: "", expires: 0 };
 
 export default interface IAuthStrategy {
     setConfiguration(configuration: SdkConfiguration): void;

--- a/src/auth/ImplicitGrantStrategy.ts
+++ b/src/auth/ImplicitGrantStrategy.ts
@@ -51,7 +51,8 @@ export default class ImplicitGrantStrategy implements IAuthStrategy {
                 access_token: accessToken,
                 token_type: hashParams.get("token_type") ?? "",
                 expires_in: parseInt(hashParams.get("expires_in") ?? "0"),
-                refresh_token: hashParams.get("refresh_token") ?? ""
+                refresh_token: hashParams.get("refresh_token") ?? "",
+                expires: Number(hashParams.get("expires")) || 0
             });
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface AccessToken {
     token_type: string;
     expires_in: number;
     refresh_token: string;
+    expires: number;
 }
 
 interface AlbumBase {


### PR DESCRIPTION
- Fixes incorrect `accessToken == emptyAccessToken` object comparison which leads the `postback` to be called before the client gets redirected to the authentication page
- Adds `expires` to the `AccessToken` type, as seen in the web API response
- Removes unnecessary and `||` and `??`  operators are scopes are already ensured to be arrays on the type level