### PR TITLE
Better Support for React

### DIFF
--- a/example_react/package-lock.json
+++ b/example_react/package-lock.json
@@ -8,7 +8,6 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
-        "dotenv": "^16.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1444,14 +1443,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/example_react/src/App.tsx
+++ b/example_react/src/App.tsx
@@ -1,17 +1,19 @@
+import { useSpotify } from './hooks/useSpotify';
+import { Scopes, SearchResults, SpotifyApi } from '../../src';
 import { useEffect, useState } from 'react'
-import { SpotifyApi, Scopes, SearchResults } from "../../src";
 import './App.css'
 
-const sdk = SpotifyApi.withUserAuthorization(
-  import.meta.env.VITE_SPOTIFY_CLIENT_ID,
-  import.meta.env.VITE_REDIRECT_TARGET,
-  Scopes.all
-);
+function App() {
+  
+  const sdk = useSpotify(
+    import.meta.env.VITE_SPOTIFY_CLIENT_ID, 
+    import.meta.env.VITE_REDIRECT_TARGET, 
+    Scopes.userDetails
+  );
 
-await sdk.authenticate();
-
-function App() { 
-  return (<SpotifySearch sdk={sdk} />)
+  return sdk
+    ? (<SpotifySearch sdk={sdk} />) 
+    : (<></>);
 }
 
 function SpotifySearch({ sdk }: { sdk: SpotifyApi}) {
@@ -22,7 +24,7 @@ function SpotifySearch({ sdk }: { sdk: SpotifyApi}) {
       const results = await sdk.search("The Beatles", ["artist"]);
       setResults(() => results);      
     })();
-  }, []);
+  }, [sdk]);
 
   // generate a table for the results
   const tableRows = results.artists?.items.map((artist) => {

--- a/example_react/src/hooks/useSpotify.ts
+++ b/example_react/src/hooks/useSpotify.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react'
+import { SpotifyApi, SdkOptions, AuthorizationCodeWithPKCEStrategy } from "../../../src";
+
+export function useSpotify(clientId: string, redirectUrl: string, scopes: string[], config?: SdkOptions) {
+
+    const [sdk, setSdk] = useState<SpotifyApi | null>(null);
+    const { current: activeScopes } = useRef(scopes);
+
+    useEffect(() => {
+        (async () => {
+            const auth = new AuthorizationCodeWithPKCEStrategy(clientId, redirectUrl, activeScopes);
+            const internalSdk = new SpotifyApi(auth, config);
+
+            try {
+                const { authenticated } = await internalSdk.authenticate();
+
+                if (authenticated) {
+                    setSdk(() => internalSdk);
+                }
+            } catch (e: Error | unknown) {
+
+                const error = e as Error;
+                if (error && error.message && error.message.includes("No verifier found in cache")) {
+                    console.error("If you are seeing this error in a React Development Environment it's because React calls useEffect twice. Using the Spotify SDK performs a token exchange that is only valid once, so React re-rendering this component will result in a second, failed authentication. This will not impact your production applications (or anything running outside of Strict Mode - which is designed for debugging components).", error);
+                } else {
+                    console.error(e);
+                }
+            }
+
+        })();
+    }, [clientId, redirectUrl, config, activeScopes]);
+
+    return sdk;
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spotify/web-api-ts-sdk",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "A typescript SDK for the Spotify Web API",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/src/SpotifyApi.test.ts
+++ b/src/SpotifyApi.test.ts
@@ -10,6 +10,7 @@ import ImplicitGrantStrategy from "./auth/ImplicitGrantStrategy";
 import ProvidedAccessTokenStrategy from "./auth/ProvidedAccessTokenStrategy";
 import { AccessToken, SdkOptions } from "./types";
 import InMemoryCachingStrategy from "./caching/InMemoryCachingStrategy";
+import exp from "constants";
 
 describe("SpotifyAPI Instance", () => {
     let sut: SpotifyApi;
@@ -93,7 +94,7 @@ describe("SpotifyAPI Instance", () => {
         it("when access token provided, it is accurately retrieved taking precedence over any existing cached token.", async () => {
             const config: SdkOptions = { cachingStrategy: new InMemoryCachingStrategy() };
             config.cachingStrategy?.setCacheItem("spotify-sdk:ProvidedAccessTokenStrategy:token", { access_token: "some-old-token" });
-            
+
             const sut = SpotifyApi.withAccessToken("client-id", { access_token: "some-new-token" } as AccessToken, config);
             const token = await sut.getAccessToken();
 
@@ -109,8 +110,9 @@ describe("SpotifyAPI Instance", () => {
         });
 
         it("authenticates successfully", async () => {
-            const accessToken = await sut.authenticate();
-            expect(accessToken.access_token).toBe(FakeAuthStrategy.FAKE_AUTH_TOKEN);
+            const response = await sut.authenticate();
+            expect(response.accessToken.access_token).toBe(FakeAuthStrategy.FAKE_AUTH_TOKEN);
+            expect(response.authenticated).toBe(true);
 
             const accessToken2 = await sut.getAccessToken();
             expect(accessToken2?.access_token).toBe(FakeAuthStrategy.FAKE_AUTH_TOKEN);

--- a/src/SpotifyApi.test.ts
+++ b/src/SpotifyApi.test.ts
@@ -10,7 +10,6 @@ import ImplicitGrantStrategy from "./auth/ImplicitGrantStrategy";
 import ProvidedAccessTokenStrategy from "./auth/ProvidedAccessTokenStrategy";
 import { AccessToken, SdkOptions } from "./types";
 import InMemoryCachingStrategy from "./caching/InMemoryCachingStrategy";
-import exp from "constants";
 
 describe("SpotifyAPI Instance", () => {
     let sut: SpotifyApi;

--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -77,6 +77,11 @@ export class SpotifyApi {
     public async makeRequest<TReturnType>(method: "GET" | "POST" | "PUT" | "DELETE", url: string, body: any = undefined, contentType: string | undefined = undefined): Promise<TReturnType> {
         try {
             const accessToken = await this.authenticationStrategy.getOrCreateAccessToken();
+            if (isEmptyAccessToken(accessToken)) {
+                console.warn("No access token found, authenticating now.");
+                return null as TReturnType;
+            }
+
             const token = accessToken?.access_token;
 
             const fullUrl = SpotifyApi.rootUrl + url;

--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -115,7 +115,6 @@ export class SpotifyApi {
 
     private initilizeSdk(config: SdkOptions | undefined): SdkConfiguration {
         const isBrowser = typeof window !== 'undefined';
-        const isNode = typeof process === 'object';
 
         const defaultConfig: SdkConfiguration = {
             fetch: (req: RequestInfo | URL, init: RequestInit | undefined) => fetch(req, init),

--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -11,7 +11,7 @@ import PlaylistsEndpoints from "./endpoints/PlaylistsEndpoints.js";
 import SearchEndpoints, { SearchExecutionFunction } from "./endpoints/SearchEndpoints.js";
 import ShowsEndpoints from "./endpoints/ShowsEndpoints.js";
 import TracksEndpoints from "./endpoints/TracksEndpoints.js";
-import IAuthStrategy, { emptyAccessToken } from "./auth/IAuthStrategy.js";
+import IAuthStrategy, { emptyAccessToken, isEmptyAccessToken } from "./auth/IAuthStrategy.js";
 import UsersEndpoints from "./endpoints/UsersEndpoints.js";
 import CurrentUserEndpoints from "./endpoints/CurrentUserEndpoints.js";
 import ClientCredentialsStrategy from "./auth/ClientCredentialsStrategy.js";
@@ -23,8 +23,8 @@ import NoOpErrorHandler from "./errorhandling/NoOpErrorHandler.js";
 import DocumentLocationRedirectionStrategy from "./redirection/DocumentLocationRedirectionStrategy.js";
 import LocalStorageCachingStrategy from "./caching/LocalStorageCachingStrategy.js";
 import InMemoryCachingStrategy from "./caching/InMemoryCachingStrategy.js";
-import type { AccessToken, SdkConfiguration, SdkOptions } from "./types.js";
 import ProvidedAccessTokenStrategy from "./auth/ProvidedAccessTokenStrategy.js";
+import type { AccessToken, SdkConfiguration, SdkOptions, AuthenticationResponse } from "./types.js";
 
 export class SpotifyApi {
     private sdkConfig: SdkConfiguration;
@@ -137,8 +137,13 @@ export class SpotifyApi {
     /**
      * Use this when you're running in a browser and you want to control when first authentication+redirect happens.
     */
-    public async authenticate(): Promise<AccessToken> {
-        return this.authenticationStrategy.getOrCreateAccessToken(); // trigger any redirects 
+    public async authenticate(): Promise<AuthenticationResponse> {
+        const response = await this.authenticationStrategy.getOrCreateAccessToken(); // trigger any redirects
+
+        return {
+            authenticated: response.expires > Date.now() && !isEmptyAccessToken(response),
+            accessToken: response
+        };
     }
 
     /**

--- a/src/auth/AccessTokenHelpers.ts
+++ b/src/auth/AccessTokenHelpers.ts
@@ -8,6 +8,10 @@ export default class AccessTokenHelpers {
     }
 
     public static toCachable(item: AccessToken): ICachable & AccessToken {
+        if (item.expires && item.expires === -1) {
+            return item;
+        }
+
         return { ...item, expires: Date.now() + (item.expires_in * 1000) };
     }
 

--- a/src/auth/IAuthStrategy.ts
+++ b/src/auth/IAuthStrategy.ts
@@ -1,7 +1,7 @@
 import type { AccessToken, SdkConfiguration } from "../types.js";
 
 export const emptyAccessToken: AccessToken = { access_token: "emptyAccessToken", token_type: "", expires_in: 0, refresh_token: "", expires: -1 };
-export function isEmptyAccessToken(value: any): value is AccessToken {
+export function isEmptyAccessToken(value: any): boolean {
     return value === emptyAccessToken;
 }
 

--- a/src/auth/IAuthStrategy.ts
+++ b/src/auth/IAuthStrategy.ts
@@ -1,6 +1,9 @@
 import type { AccessToken, SdkConfiguration } from "../types.js";
 
-export const emptyAccessToken: AccessToken = { access_token: "", token_type: "", expires_in: 0, refresh_token: "", expires: 0 };
+export const emptyAccessToken: AccessToken = { access_token: "emptyAccessToken", token_type: "", expires_in: 0, refresh_token: "", expires: -1 };
+export function isEmptyAccessToken(value: any): value is AccessToken {
+    return value === emptyAccessToken;
+}
 
 export default interface IAuthStrategy {
     setConfiguration(configuration: SdkConfiguration): void;

--- a/src/caching/GenericCache.ts
+++ b/src/caching/GenericCache.ts
@@ -1,3 +1,4 @@
+import { isEmptyAccessToken } from "../auth/IAuthStrategy.js";
 import { ICachingStrategy, ICachable } from "../types.js";
 import { ICacheStore } from "./ICacheStore.js";
 
@@ -21,6 +22,7 @@ export default class GenericCache implements ICachingStrategy {
         if (updateFunction) {
             this.updateFunctions.set(cacheKey, updateFunction);
         }
+
         const item = await this.get<T>(cacheKey);
         if (item) {
             return item;
@@ -31,8 +33,9 @@ export default class GenericCache implements ICachingStrategy {
             throw new Error("Could not create cache item");
         }
 
-        this.setCacheItem(cacheKey, newCacheItem);
-        
+        if (!isEmptyAccessToken(newCacheItem)) {
+            this.setCacheItem(cacheKey, newCacheItem);
+        }
 
         return newCacheItem;
     }

--- a/src/test/FakeAuthStrategy.ts
+++ b/src/test/FakeAuthStrategy.ts
@@ -23,6 +23,7 @@ export class FakeAuthStrategy implements IAuthStrategy {
             async () => {
                 return {
                     access_token: this.accessToken,
+                    expires: Date.now() + 3600 * 1000,
                 } as AccessToken;
             },
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,11 @@ export interface SdkOptions {
     cachingStrategy?: ICachingStrategy;
 }
 
+export interface AuthenticationResponse {
+    authenticated: boolean;
+    accessToken: AccessToken;
+}
+
 export interface SdkConfiguration extends SdkOptions {
     fetch: RequestImplementation;
     beforeRequest: (url: string, options: RequestInit) => void;


### PR DESCRIPTION
This PR is a rollup of a few confusing issues that have been impacting folks most specifically here: https://github.com/spotify/spotify-web-api-ts-sdk/issues/47

1. Cleaned up some of the confusing code around the `emptyAccessToken` - this is a null-object that's used to represent a pending authentication. It confusingly was being put into the cache in local storage and confusing folks trying to debug rendering issues. This token no longer gets cached, or really returned anywhere outside of the internals of the library.

2. Changed the way cache expiries were being verified - again, it was letting the `emptyAccessToken` masquerade as a real token. All this wouldn't be particularly important if it weren't for...

3. Better React examples!

---
### What

I've overhauled the React example to use a custom react hook that's much better example of how people should use this with react. Like most things to do with React there are gotchas.

---
### Why

Since React 16, components and hooks that make use of `useEffect` render twice on component mount when in React Strict mode. Strict mode is designed to troubleshoot any potentially problematic components during development by mounting, then rapidly unmounting and remounting components - mostly to try and detect components and effects with side effects.

Which this is. And must be, because, well, we have state and API tokens. Square peg, round hole.

---
### How

_However, when all you have is a square peg..._

This is the new example React app - which is pretty lovely...

```tsx
import { useSpotify } from './hooks/useSpotify';
import { Scopes, SearchResults, SpotifyApi } from '../../src';
import { useEffect, useState } from 'react'
import './App.css'

function App() {
  
  const sdk = useSpotify(
    import.meta.env.VITE_SPOTIFY_CLIENT_ID, 
    import.meta.env.VITE_REDIRECT_TARGET, 
    Scopes.userDetails
  );

  return sdk
    ? (<SpotifySearch sdk={sdk} />) 
    : (<></>);
}

function SpotifySearch({ sdk }: { sdk: SpotifyApi}) {
  const [results, setResults] = useState<SearchResults>({} as SearchResults);

  useEffect(() => {
    (async () => {
      const results = await sdk.search("The Beatles", ["artist"]);
      setResults(() => results);      
    })();
  }, [sdk]);

  // generate a table for the results
  const tableRows = results.artists?.items.map((artist) => {
    return (
      <tr key={artist.id}>
        <td>{artist.name}</td>
        <td>{artist.popularity}</td>
        <td>{artist.followers.total}</td>
      </tr>
    );
  });

  return (
    <>
      <h1>Spotify Search for The Beatles</h1>
      <table>
        <thead>
          <tr>
            <th>Name</th>
            <th>Popularity</th>
            <th>Followers</th>
          </tr>
        </thead>
        <tbody>
          {tableRows}
        </tbody>
      </table>
    </>
  )
}

export default App;
```

This is built on top of the new hook, which... is a lot uglier, but hides all the chaos

```tsx
import { useEffect, useRef, useState } from 'react'
import { SpotifyApi, SdkOptions, AuthorizationCodeWithPKCEStrategy } from "../../../src";

export function useSpotify(clientId: string, redirectUrl: string, scopes: string[], config?: SdkOptions) {

    const [sdk, setSdk] = useState<SpotifyApi | null>(null);
    const { current: activeScopes } = useRef(scopes);

    useEffect(() => {
        (async () => {
            const auth = new AuthorizationCodeWithPKCEStrategy(clientId, redirectUrl, activeScopes);
            const internalSdk = new SpotifyApi(auth, config);

            try {
                const { authenticated } = await internalSdk.authenticate();

                if (authenticated) {
                    setSdk(() => internalSdk);
                }
            } catch (e: Error | unknown) {

                const error = e as Error;
                if (error && error.message && error.message.includes("No verifier found in cache")) {
                    console.error("If you are seeing this error in a React Development Environment it's because React calls useEffect twice. Using the Spotify SDK performs a token exchange that is only valid once, so React re-rendering this component will result in a second, failed authentication. This will not impact your production applications (or anything running outside of Strict Mode - which is designed for debugging components).", error);
                } else {
                    console.error(e);
                }
            }

        })();
    }, [clientId, redirectUrl, config, activeScopes]);

    return sdk;
}
```

You may notice that there's a novel of a warning in there - that's because while we can make this hook work nicely in Strict Mode, we can't really stop any errors from appearing in the console. Once we've done a successful token exchange, you can't use the oAuth code again, and when you try, it throws an error, like it or not.

To minimise the effect of reacts fun and games on the rest of the codebase, I'm just catching auth errors in the react component, and detecting the one that fails in this specific scenario to present a friendlier error message to the developers who are going to see it.

It's imperfect, but there's a tonne of edge cases around other approaches (we could cache the code, and it'd fail differently, we could try short circuit the codebase and return tokens from localStorage, but it's ugly and more disruptive to the rest of the code than just doing the obvious thing and making it a react-facing problem).

Please accept my apologies for this novel, I'm sure if you've read this far, you've probably come up with a smarter way to fix this and are looking for answers!