### PR TITLE
Fix return type on topItems

### DIFF
--- a/src/endpoints/CurrentUserEndpoints.ts
+++ b/src/endpoints/CurrentUserEndpoints.ts
@@ -1,5 +1,5 @@
 import { SpotifyApi } from '../SpotifyApi.js';
-import type { User, Page, Artist, MaxInt, FollowedArtists, Market, SavedAlbum, SimplifiedAudiobook, SimplifiedPlaylist, SavedEpisode, SavedShow, SavedTrack } from '../types.js';
+import type { User, Page, Artist, Track, MaxInt, FollowedArtists, Market, SavedAlbum, SimplifiedAudiobook, SimplifiedPlaylist, SavedEpisode, SavedShow, SavedTrack } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export default class CurrentUserEndpoints extends EndpointsBase {
@@ -25,11 +25,10 @@ export default class CurrentUserEndpoints extends EndpointsBase {
         return this.getRequest<User>('me');
     }
 
-    public topItems(type: "artists" | "tracks"): Promise<Page<Artist>>;
-    public topItems(type: "artists" | "tracks", time_range?: 'short_term' | 'medium_term' | 'long_term', limit?: MaxInt<50>, offset?: number): Promise<Page<Artist>>;
-    public topItems(type: "artists" | "tracks", time_range?: 'short_term' | 'medium_term' | 'long_term', limit?: MaxInt<50>, offset?: number) {
+    public topItems<T extends "artists" | "tracks">(type: T, time_range?: 'short_term' | 'medium_term' | 'long_term', limit?: MaxInt<50>, offset?: number)
+    {
         const params = this.paramsFor({ time_range, limit, offset });
-        return this.getRequest<Page<Artist>>(`me/top/${type}${params}`);
+        return this.getRequest<Page<T extends "artists" ? Artist : Track>>(`me/top/${type}${params}`);
     }
 
     public followedArtists(after?: string, limit?: MaxInt<50>) {


### PR DESCRIPTION
### Problem

`topItems` currently returns a type of **only** `Promise<Page<Artist>>`, even when passing `"tracks"` as the `type` input. 

The User's Top Items endpoint can return either an array of ArtistObject or TrackObject [as documented here](https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks).

### Solution

Refactor the `topItems` function to introduce a generic type parameter so that passing `"artists"` or `"tracks"` returns `Promise<Page<Artist>>` or `Promise<Page<Track>>` respectively.

### Result

`topItems` now has a different return value based on what's passed for `type`!
```ts
const trackItems: Page<Track> = await spotifyApi.currentUser.topItems("tracks")

const artistItems: Page<Artist> = await spotifyApi.currentUser.topItems("artists")
```