### PR TITLE
fix comparison of accessToken.expires and Data.now

### DIFF
--- a/src/auth/ProvidedAccessTokenStrategy.ts
+++ b/src/auth/ProvidedAccessTokenStrategy.ts
@@ -21,7 +21,7 @@ export default class ProvidedAccessTokenStrategy implements IAuthStrategy {
     }
 
     public async getOrCreateAccessToken(): Promise<AccessToken> {
-        if (this.accessToken.expires <= Date.now()) {
+        if (this.accessToken.expires * 1000 <= Date.now()) {
             const refreshed = await AccessTokenHelpers.refreshCachedAccessToken(this.clientId, this.accessToken);
             this.accessToken = refreshed;
         }


### PR DESCRIPTION
found this little guy after a couple of hours of gaslighting myself.
I checked with the rest of the codebase and it looks like the *1000 multiplier got missed in this one method.