### PR TITLE
Fix additional_types parameter in player API

### DIFF
--- a/src/endpoints/PlayerEndpoints.ts
+++ b/src/endpoints/PlayerEndpoints.ts
@@ -7,8 +7,8 @@ interface QueryRange {
 }
 
 export default class PlayerEndpoints extends EndpointsBase {
-    public getPlaybackState(market?: Market, additionalTypes?: string) {
-        const params = this.paramsFor({ market, additionalTypes });
+    public getPlaybackState(market?: Market, additional_types?: string) {
+        const params = this.paramsFor({ market, additional_types });
         return this.getRequest<PlaybackState>(`me/player${params}`);
     }
 
@@ -16,8 +16,8 @@ export default class PlayerEndpoints extends EndpointsBase {
         return this.getRequest<Devices>('me/player/devices');
     }
 
-    public getCurrentlyPlayingTrack(market?: Market, additionalTypes?: string) {
-        const params = this.paramsFor({ market, additionalTypes });
+    public getCurrentlyPlayingTrack(market?: Market, additional_types?: string) {
+        const params = this.paramsFor({ market, additional_types });
         return this.getRequest<PlaybackState>(`me/player/currently-playing${params}`);
     }
 


### PR DESCRIPTION
Corrected error spotted by user @Smirow where the additional_types param was mapped as additionalTypes.

This fixes issue: https://github.com/spotify/spotify-web-api-ts-sdk/issues/59