### PR TITLE
types: mark search result properties as optional unless explicited

### DIFF
--- a/src/endpoints/SearchEndpoints.test.ts
+++ b/src/endpoints/SearchEndpoints.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 import { buildIntegrationTestSdkInstance } from "../test/SpotifyApiBuilder";
 import { SpotifyApi } from "../SpotifyApi";
 import { FetchApiSpy } from "../test/FetchApiSpy";
+import { Artist, ItemTypes, Page } from "../types";
 
 describe("Integration: Search Endpoints", () => {
     let sut: SpotifyApi;
@@ -18,4 +19,19 @@ describe("Integration: Search Endpoints", () => {
         expect(fetchSpy.request(0).input).toBe(`https://api.spotify.com/v1/search?q=${q}&type=artist`);
         expect(result.artists.items[0].name).toBe("Katatonia");
     });
+
+    it("result type should mark properties as optional if they can\'t be determined", async () => {
+        const q = "Katatonia"
+        const types: ItemTypes[] = ["artist"]
+        const result = await sut.search(q, types);
+
+        expectTypeOf(result).toMatchTypeOf<{ artists?: Page<Artist> }>
+    })
+    
+    it("result type should assert property as present if types are passed as a tuple", async () => {
+        const q = "Katatonia"
+        const result = await sut.search(q, ['artist']);
+
+        expectTypeOf(result).toEqualTypeOf<{ artists: Page<Artist> }>
+    })
 });

--- a/src/endpoints/SearchEndpoints.ts
+++ b/src/endpoints/SearchEndpoints.ts
@@ -2,12 +2,12 @@ import type { ItemTypes, Market, MaxInt, SearchResults } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export interface SearchExecutionFunction {
-    (q: string, type: ItemTypes[], market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults>;
+    <const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>>;
 }
 
 export default class SearchEndpoints extends EndpointsBase {
-    public async execute(q: string, type: ItemTypes[], market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string) {
+    public async execute<const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string) {
         const params = this.paramsFor({ q, type, market, limit, offset, include_external });
-        return await this.getRequest<SearchResults>(`search${params}`);
+        return await this.getRequest<SearchResults<T>>(`search${params}`);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,15 +244,39 @@ export interface ExternalUrls {
     spotify: string
 }
 
-export interface SearchResults {
-    tracks: Page<Track>
-    artists: Page<Artist>
-    albums: Page<SimplifiedAlbum>
-    playlists: Page<PlaylistBase>
-    shows: Page<SimplifiedShow>
-    episodes: Page<SimplifiedEpisode>
-    audiobooks: Page<SimplifiedAudiobook>
+
+interface ResourceTypeToResultKey {
+  album: 'albums'
+  artist: 'artists'
+  track: 'tracks'
+  playlist: 'playlists'
+  show: 'shows'
+  episode: 'episodes'
+  audiobook: 'audiobooks'
 }
+
+interface SearchResultsMap {
+  album: SimplifiedAlbum
+  artist: Artist
+  track: Track
+  playlist: PlaylistBase
+  show: SimplifiedShow
+  episode: SimplifiedEpisode
+  audiobook: SimplifiedAudiobook
+}
+
+export type PartialSearchResult = {
+    [K in ItemTypes as ResourceTypeToResultKey[K]]?: Page<K extends keyof SearchResultsMap ? SearchResultsMap[K] : any>
+  }
+  
+/**
+ * Makes all properties in SearchResults optional, unless the type T is a tuple (literal array / tuple) of SearchTypes.
+ */
+export type SearchResults<T extends readonly ItemTypes[]> = Pick<PartialSearchResult, ResourceTypeToResultKey[T[number]]> extends infer R
+? number extends T['length']
+    ? R
+    : Required<R>
+: never
 
 export interface ArtistSearchResult {
     href: string;


### PR DESCRIPTION
Spotify API informs that the endpoint only returns the requested types as keys of the response payload.

Currently, the type marks every property as present but it's not accurate. This new type marks the properties as optional, unless the static analyser is capable of determining the value is a tuple, in which case it is capable to narrow down what properties will be present.

![image](https://github.com/spotify/spotify-web-api-ts-sdk/assets/19751938/09bfbab1-aad2-4e21-bd69-a2379b848d7a)
![image](https://github.com/spotify/spotify-web-api-ts-sdk/assets/19751938/7603f9be-7853-496b-bbe1-221000a8714b)

Sorry about the test naming, I'm not sure the titles are accurate.