### PR TITLE
Correctly encode 0 numerical values when added as query string parameters.

### DIFF
--- a/src/endpoints/EndpointsBase.test.ts
+++ b/src/endpoints/EndpointsBase.test.ts
@@ -4,20 +4,6 @@ import EndpointsBase from "./EndpointsBase";
 import { FetchApiSpy } from "../test/FetchApiSpy";
 import { SpotifyApi } from "../SpotifyApi";
 
-class FakeEndPoints extends EndpointsBase {
-    public functionWithStringParam(id: string) {
-        return this.paramsFor({ id });
-    }
-
-    public functionWithStringArrayParam(ids: string[]) {
-        return this.paramsFor({ ids });
-    }
-
-    public functionWithBooleanParam(id: boolean) {
-        return this.paramsFor({ id });
-    }
-}
-
 describe("EndpointsBase", async () => {
 
     let api: SpotifyApi;
@@ -27,6 +13,16 @@ describe("EndpointsBase", async () => {
     beforeEach(() => {
         [api, fetchSpy] = buildIntegrationTestUserSdkInstance();
         sut = new FakeEndPoints(api);
+    });
+
+    it("paramsFor omitts undefined", () => {
+        const result = sut.functionThatPassesUndefined();
+        expect(result).toBe("");
+    });
+
+    it("paramsFor omitts null", () => {
+        const result = sut.functionThatPassesNull();
+        expect(result).toBe("");
     });
 
     it("paramsFor can correctly url encode a string", () => {
@@ -44,4 +40,40 @@ describe("EndpointsBase", async () => {
         expect(result).toBe("?id=false");
     });
 
+    it("paramsFor can correctly url encode a 0", () => {
+        const result = sut.functionWitNumericParam(0);
+        expect(result).toBe("?id=0");
+    });
+
+    it("paramsFor can correctly url encode a non-zero number", () => {
+        const result = sut.functionWitNumericParam(1);
+        expect(result).toBe("?id=1");
+    });
 });
+
+
+class FakeEndPoints extends EndpointsBase {
+    public functionThatPassesUndefined() {
+        return this.paramsFor({ id: undefined });
+    }
+    
+    public functionThatPassesNull() {
+        return this.paramsFor({ id: null });
+    }
+    
+    public functionWithStringParam(id: string) {
+        return this.paramsFor({ id });
+    }
+
+    public functionWithStringArrayParam(ids: string[]) {
+        return this.paramsFor({ ids });
+    }
+
+    public functionWithBooleanParam(id: boolean) {
+        return this.paramsFor({ id });
+    }
+
+    public functionWitNumericParam(id: number) {
+        return this.paramsFor({ id });
+    }
+}

--- a/src/endpoints/EndpointsBase.ts
+++ b/src/endpoints/EndpointsBase.ts
@@ -23,7 +23,7 @@ export default class EndpointsBase {
     protected paramsFor(args: any) {
         const params = new URLSearchParams();
         for (let key of Object.getOwnPropertyNames(args)) {
-            if (args[key] || (!args[key] && typeof args[key] === 'boolean')) {
+            if (args[key] || (args[key] === 0) || (!args[key] && typeof args[key] === 'boolean')) {
                 params.append(key, args[key].toString());
             }
         }


### PR DESCRIPTION
Currently, if you try pass a 0 as a parameter to any API call, it'll fail.

Luckily, that's not something people really want to do very often, except when they try to set a volume to 0.
The monsters, trying to stop the music!

This PR fixes passing 0 values as qs params.

Fixes issue: https://github.com/spotify/spotify-web-api-ts-sdk/issues/71