### PR TITLE
Adds npm install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Because this SDK uses `fetch` both in Node and the Browser, and ESM, we require 
 
 The package contains both an ESM and CommonJS build, so you can use it in both Node and the Browser.
 
+## Using this in your project
+
+```bash
+npm install @spotify/web-api-ts-sdk
+```
+
 ## Running the example app
 
 First install the dependencies:


### PR DESCRIPTION
Problem
The README does not currently show how to install this sdk in a project. Adding this line to the README allows developers to easily install this sdk without having to find it in the npm registry. Developers can now copy this easily from the README on github!

Solution

I've added a code block with the proper npm registry install link! This was found at https://www.npmjs.com/package/@spotify/web-api-ts-sdk