### PR TITLE
Fix TS error on SearchEndpoints

### DIFF
--- a/src/endpoints/SearchEndpoints.ts
+++ b/src/endpoints/SearchEndpoints.ts
@@ -2,11 +2,11 @@ import type { ItemTypes, Market, MaxInt, SearchResults } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export interface SearchExecutionFunction {
-    <const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>>;
+    <T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>>;
 }
 
 export default class SearchEndpoints extends EndpointsBase {
-    public async execute<const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string) {
+    public async execute<T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string) {
         const params = this.paramsFor({ q, type, market, limit, offset, include_external });
         return await this.getRequest<SearchResults<T>>(`search${params}`);
     }


### PR DESCRIPTION
Was getting a type error on search using Typescript 5.2.2:
![image](https://github.com/spotify/spotify-web-api-ts-sdk/assets/63693423/16485d20-36fc-47c1-a03f-932a64c752c7)

Turns out const was causing a type error:
![image](https://github.com/spotify/spotify-web-api-ts-sdk/assets/63693423/c8923759-9669-4309-9f59-16a77eef1791)

Removing const fixed the errors:
![image](https://github.com/spotify/spotify-web-api-ts-sdk/assets/63693423/c83bf63f-c075-41c2-86cc-d6ee4a3ab92b)
