### PR TITLE
[FIX] Correct generic type constraint in SearchEndpoints

### DIFF
--- a/src/endpoints/SearchEndpoints.ts
+++ b/src/endpoints/SearchEndpoints.ts
@@ -2,11 +2,11 @@ import type { ItemTypes, Market, MaxInt, SearchResults } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export interface SearchExecutionFunction {
-    <const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>>;
+  <T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>>;
 }
 
 export default class SearchEndpoints extends EndpointsBase {
-    public async execute<const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string) {
+    public async execute<T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string) {
         const params = this.paramsFor({ q, type, market, limit, offset, include_external });
         return await this.getRequest<SearchResults<T>>(`search${params}`);
     }


### PR DESCRIPTION
**Problem**

The existing type declaration in the SearchEndpoints class within the @spotify/web-api-ts-sdk package contains an invalid use of the const keyword within a generic type constraint. This syntax is not valid in TypeScript and causes a type error during the build process. The issue arises from the use of `<const T extends readonly ItemTypes[]>` in the type definition, which is not a recognized TypeScript syntax for generic type constraints.

**Solution**

The invalid const keyword has been removed from the generic type constraint, resulting in the correct syntax `<T extends readonly ItemTypes[]>`. This change has been applied to both the SearchExecutionFunction type and the execute method within the SearchEndpoints class. The corrected type declaration ensures that the code adheres to TypeScript's syntax rules and will compile without errors.

**Result**

Upon applying this fix, the type declaration issue will be resolved, and the SearchEndpoints class will function as intended without any type-related compilation errors. This change will also improve the maintainability and reliability of the codebase by adhering to TypeScript's best practices for generics.