### PR TITLE
feat: stateful redirect for implicitgrantstrategy

### DIFF
--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -141,8 +141,8 @@ export class SpotifyApi {
     /**
      * Use this when you're running in a browser and you want to control when first authentication+redirect happens.
     */
-    public async authenticate(): Promise<AuthenticationResponse> {
-        const response = await this.authenticationStrategy.getOrCreateAccessToken(); // trigger any redirects
+    public async authenticate(state?: string): Promise<AuthenticationResponse> {
+        const response = await this.authenticationStrategy.getOrCreateAccessToken(state); // trigger any redirects
 
         return {
             authenticated: response.expires! > Date.now() && !isEmptyAccessToken(response),

--- a/src/auth/IAuthStrategy.ts
+++ b/src/auth/IAuthStrategy.ts
@@ -7,7 +7,7 @@ export function isEmptyAccessToken(value: any): boolean {
 
 export default interface IAuthStrategy {
     setConfiguration(configuration: SdkConfiguration): void;
-    getOrCreateAccessToken(): Promise<AccessToken>;
+    getOrCreateAccessToken(state?: string): Promise<AccessToken>;
     getAccessToken(): Promise<AccessToken | null>;
     removeAccessToken(): void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface AccessToken {
     expires_in: number;
     refresh_token: string;
     expires?: number;
+    state?: string,
 }
 
 interface AlbumBase {


### PR DESCRIPTION
<!-- See: CONTRIBUTING.md#Pull-Requests -->

### Summary

<!-- Explain the context and why you're making that change.  What is the problem you're trying to solve? -->

### Changes

https://github.com/spotify/spotify-web-api-ts-sdk/issues/109

It's recommended in the docs and afaik as good practice to preserve some sort of `state` during an auth flow like this. Currently with this library there's no way to send in state during the authorization that I can get back on redirect and verify.

<!-- Describe the solution and changes that you have made -->

### Results

My changes only include an update to enable stateful redirect on the ImplicitGrantStrategy and I believe I've done it in a non-breaking way with an optional string argument

When a client using the ImplicitGrantStrategy calls `authorize` on the main SpotifyApi object, they can now provide a `state` string as an argument that they can expect to see on the redirectUri after a successful authentication

<!-- Describe expected new behaviour, as well as any steps on how to test / verify. -->

I've opened this as a draft PR only for the ImplicitGrantStrategy for the time being to see if this is something that's even wanted by others using this library. If the maintainers like the feature then I'd be happy to expand on this PR or provide follow up PRs to implement stateful redirect for other applicable flows.
