### PR TITLE
fix: return correct types instead of casting with as 

### DIFF
--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -74,12 +74,12 @@ export class SpotifyApi {
         this.authenticationStrategy.setConfiguration(this.sdkConfig);
     }
 
-    public async makeRequest<TReturnType>(method: "GET" | "POST" | "PUT" | "DELETE", url: string, body: any = undefined, contentType: string | undefined = undefined): Promise<TReturnType> {
+    public async makeRequest<TReturnType>(method: "GET" | "POST" | "PUT" | "DELETE", url: string, body: any = undefined, contentType: string | undefined = undefined): Promise<TReturnType|null> {
         try {
             const accessToken = await this.authenticationStrategy.getOrCreateAccessToken();
             if (isEmptyAccessToken(accessToken)) {
                 console.warn("No access token found, authenticating now.");
-                return null as TReturnType;
+                return null;
             }
 
             const token = accessToken?.access_token;
@@ -99,7 +99,7 @@ export class SpotifyApi {
             this.sdkConfig.afterRequest(fullUrl, opts, result);
 
             if (result.status === 204) {
-                return null as TReturnType;
+                return null;
             }
 
             await this.sdkConfig.responseValidator.validateResponse(result);
@@ -109,7 +109,7 @@ export class SpotifyApi {
             if (!handled) {
                 throw error;
             }
-            return null as TReturnType;
+            return null;
         }
     }
 

--- a/src/auth/ClientCredentialsStrategy.ts
+++ b/src/auth/ClientCredentialsStrategy.ts
@@ -45,10 +45,10 @@ export default class ClientCredentialsStrategy implements IAuthStrategy {
     }
 
     private async getTokenFromApi(): Promise<AccessToken> {
-        const options = {
+        const options: Record<string,string> = {
             grant_type: 'client_credentials',
             scope: this.scopes.join(' ')
-        } as any;
+        };
 
         const bodyAsString = Object.keys(options).map(key => key + '=' + options[key]).join('&');
         const hasBuffer = typeof Buffer !== 'undefined';

--- a/src/endpoints/AlbumsEndpoints.ts
+++ b/src/endpoints/AlbumsEndpoints.ts
@@ -15,7 +15,7 @@ export default class AlbumsEndpoints extends EndpointsBase {
         const params = this.paramsFor({ ids: idOrIds, market });
         // TODO: only returns top 20, validate here
         const response = await this.getRequest<Albums>(`albums${params}`);
-        return response.albums;
+        return response?.albums;
     }
 
     public tracks(albumId: string, market?: Market, limit?: MaxInt<50>, offset?: number) {

--- a/src/endpoints/ArtistsEndpoints.ts
+++ b/src/endpoints/ArtistsEndpoints.ts
@@ -21,7 +21,7 @@ export default class ArtistsEndpoints extends EndpointsBase {
 
         const params = this.paramsFor({ ids: idOrIds });
         const response = await this.getRequest<Artists>(`artists${params}`);
-        return response.artists;
+        return response?.artists;
     }
 
     public albums(

--- a/src/endpoints/AudiobooksEndpoints.ts
+++ b/src/endpoints/AudiobooksEndpoints.ts
@@ -12,7 +12,7 @@ export default class AudiobooksEndpoints extends EndpointsBase {
 
         const params = this.paramsFor({ ids: idOrIds, market });
         const response = await this.getRequest<Audiobooks>(`audiobooks${params}`);
-        return response.audiobooks;
+        return response?.audiobooks;
     }
 
     public getAudiobookChapters(id: string, market?: Market, limit?: MaxInt<50>, offset?: number) {

--- a/src/endpoints/ChaptersEndpoints.ts
+++ b/src/endpoints/ChaptersEndpoints.ts
@@ -16,6 +16,6 @@ export default class ChaptersEndpoints extends EndpointsBase {
         // TODO: Only returns top 50, validate / pre-check here
         const params = this.paramsFor({ ids: idOrIds, market });
         const response = await this.getRequest<Chapters>(`chapters${params}`);
-        return response.chapters;
+        return response?.chapters;
     }
 }

--- a/src/endpoints/EndpointsBase.ts
+++ b/src/endpoints/EndpointsBase.ts
@@ -4,19 +4,19 @@ export default class EndpointsBase {
     constructor(protected api: SpotifyApi) {
     }
 
-    protected async getRequest<TReturnType>(url: string): Promise<TReturnType> {
+    protected async getRequest<TReturnType>(url: string): Promise<TReturnType|null> {
         return await this.api.makeRequest<TReturnType>("GET", url);
     }
 
-    protected async postRequest<TReturnType, TBody = unknown>(url: string, body?: TBody, contentType: string | undefined = undefined): Promise<TReturnType> {
+    protected async postRequest<TReturnType, TBody = unknown>(url: string, body?: TBody, contentType: string | undefined = undefined): Promise<TReturnType|null> {
         return await this.api.makeRequest<TReturnType>("POST", url, body, contentType);
     }
 
-    protected async putRequest<TReturnType, TBody = unknown>(url: string, body?: TBody, contentType: string | undefined = undefined): Promise<TReturnType> {
+    protected async putRequest<TReturnType, TBody = unknown>(url: string, body?: TBody, contentType: string | undefined = undefined): Promise<TReturnType|null> {
         return await this.api.makeRequest<TReturnType>("PUT", url, body, contentType);
     }
 
-    protected async deleteRequest<TReturnType, TBody = unknown>(url: string, body?: TBody): Promise<TReturnType> {
+    protected async deleteRequest<TReturnType, TBody = unknown>(url: string, body?: TBody): Promise<TReturnType|null> {
         return await this.api.makeRequest<TReturnType>("DELETE", url, body);
     }
 

--- a/src/endpoints/EpisodesEndpoints.ts
+++ b/src/endpoints/EpisodesEndpoints.ts
@@ -13,6 +13,6 @@ export default class EpisodesEndpoints extends EndpointsBase {
 
         const params = this.paramsFor({ ids: idOrIds, market });
         const response = await this.getRequest<Episodes>(`episodes${params}`);
-        return response.episodes;
+        return response?.episodes;
     }
 }

--- a/src/endpoints/SearchEndpoints.ts
+++ b/src/endpoints/SearchEndpoints.ts
@@ -2,7 +2,7 @@ import type { ItemTypes, Market, MaxInt, SearchResults } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
 
 export interface SearchExecutionFunction {
-    <const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>>;
+    <const T extends readonly ItemTypes[]>(q: string, type: T, market?: Market, limit?: MaxInt<50>, offset?: number, include_external?: string): Promise<SearchResults<T>|null>;
 }
 
 export default class SearchEndpoints extends EndpointsBase {

--- a/src/endpoints/ShowsEndpoints.ts
+++ b/src/endpoints/ShowsEndpoints.ts
@@ -14,7 +14,7 @@ export default class ShowsEndpoints extends EndpointsBase {
         // TODO: only returns 50, validate here
         const params = this.paramsFor({ ids: idOrIds, market });
         const response = await this.getRequest<Shows>(`shows${params}`);
-        return response.shows;
+        return response?.shows;
     }
 
     public episodes(id: string, market?: Market, limit?: MaxInt<50>, offset?: number) {

--- a/src/endpoints/TracksEndpoints.ts
+++ b/src/endpoints/TracksEndpoints.ts
@@ -14,7 +14,7 @@ export default class TracksEndpoints extends EndpointsBase {
         const params = this.paramsFor({ ids: idOrIds, market });
         // TODO: only returns top 20, validate here
         const response = await this.getRequest<Tracks>(`tracks${params}`);
-        return response.tracks;
+        return response?.tracks;
     }
 
     public audioFeatures(id: string): Promise<AudioFeatures>
@@ -25,7 +25,7 @@ export default class TracksEndpoints extends EndpointsBase {
         }
         const params = this.paramsFor({ ids: idOrIds });
         const response = await this.getRequest<AudioFeaturesCollection>(`audio-features${params}`);
-        return response.audio_features;
+        return response?.audio_features;
     }
 
     public audioAnalysis(id: string) {

--- a/src/serialization/DefaultResponseDeserializer.ts
+++ b/src/serialization/DefaultResponseDeserializer.ts
@@ -1,7 +1,7 @@
 import type { IResponseDeserializer } from "../types.js";
 
 export default class DefaultResponseDeserializer implements IResponseDeserializer {
-    public async deserialize<TReturnType>(response: Response): Promise<TReturnType> {
+    public async deserialize<TReturnType>(response: Response): Promise<TReturnType|null> {
         const text = await response.text();
 
         if (text.length > 0) {
@@ -9,6 +9,6 @@ export default class DefaultResponseDeserializer implements IResponseDeserialize
             return json as TReturnType;
         }
 
-        return null as TReturnType;
+        return null;
     }
 }

--- a/src/test/FakeAuthStrategy.ts
+++ b/src/test/FakeAuthStrategy.ts
@@ -10,6 +10,7 @@ export class FakeAuthStrategy implements IAuthStrategy {
 
     constructor(
         protected accessToken: string = FakeAuthStrategy.FAKE_AUTH_TOKEN,
+        protected refreshToken: string = FakeAuthStrategy.FAKE_AUTH_TOKEN,
     ) {
         this.cache = new InMemoryCachingStrategy();
     }
@@ -24,7 +25,10 @@ export class FakeAuthStrategy implements IAuthStrategy {
                 return {
                     access_token: this.accessToken,
                     expires: Date.now() + 3600 * 1000,
-                } as AccessToken;
+                    token_type: "Bearer",
+                    refresh_token: this.refreshToken,
+                    expires_in: 3600,
+                } satisfies AccessToken;
             },
         );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface IValidateResponses {
 }
 
 export interface IResponseDeserializer {
-    deserialize<TReturnType>(response: Response): Promise<TReturnType>;
+    deserialize<TReturnType>(response: Response): Promise<TReturnType|null>;
 }
 
 export interface ICachingStrategy {


### PR DESCRIPTION
BREAKING CHANGE: This changes the return type of all endpoints during development, as they can now return undefined in Typescript land

### Summary

The SpotifyApi class makeRequest has a return type of `Promise<TReturnType>`, but it can and will return `Promise<null>` in some cases
- https://github.com/spotify/spotify-web-api-ts-sdk/blob/main/src/SpotifyApi.ts#L82
- https://github.com/spotify/spotify-web-api-ts-sdk/blob/main/src/SpotifyApi.ts#L102
- https://github.com/spotify/spotify-web-api-ts-sdk/blob/main/src/SpotifyApi.ts#L112

### Changes

This can cause exceptions when using the SDK. So this PR fixes this to use the actual type `Promise<TReturnType|null>`, so these errors can be caught during the type check in development.

### Results

No actual changes in behaviour, just in the Typescript types
