### PR TITLE
Fix import path for globals.css

### DIFF
--- a/example_next/src/app/layout.tsx
+++ b/example_next/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import authOptions from "@/app/api/auth/[...nextauth]/authOptions";
-import "@/globals.css";
+import "@/app/globals.css";
 import AuthSessionProvider from "@/components/AuthSessionProvider";
 import { getServerSession } from "next-auth";
 import { Inter } from "next/font/google";


### PR DESCRIPTION
### Summary

Fixed import statement for the Next.js example. 

### Changes

Changing:

import "@/globals.css"

to:

import "@/app/globals.css"


### Results

I was trying to run the Next.js example and found that this import statement was pointing to the wrong place. This change fixes it.
