### PR TITLE
fix(deserializer): try-catch, to prevent parsing non deserializable responses

### DIFF
--- a/src/serialization/DefaultResponseDeserializer.ts
+++ b/src/serialization/DefaultResponseDeserializer.ts
@@ -5,8 +5,12 @@ export default class DefaultResponseDeserializer implements IResponseDeserialize
         const text = await response.text();
 
         if (text.length > 0) {
-            const json = JSON.parse(text);
-            return json as TReturnType;
+            try {
+                const json = JSON.parse(text);
+                return json as TReturnType;
+            } catch (error) {
+                //This error is thrown falsely, no log needed
+            }
         }
 
         return null as TReturnType;


### PR DESCRIPTION
fix: add try-catch, to prevent parsing non deserializable responses


Problem

Requests answering empty Responses (like Pause Playback) are currently responding non-deserializable content. 
This leads to a falsely thrown error.

Solution

I added a try-catch block to DefaultResponseDeserializer#deserialize to prevent the error.
I intentionally did not include logging in the catch-block because the error is falsely thrown.

Result

This only applies to Requests with empty Responses returning non-deserializable content.
It should not break any code