### PR TITLE
feat: update playlist endpoints from /tracks to /items

### DIFF
--- a/src/endpoints/BrowseEndpoints.ts
+++ b/src/endpoints/BrowseEndpoints.ts
@@ -15,11 +15,13 @@ export default class BrowseEndpoints extends EndpointsBase {
         return this.getRequest<Category>(`browse/categories/${categoryId}${params}`);
     }
 
+    /** @deprecated This endpoint is deprecated by the Spotify Web API. */
     public getNewReleases(country?: string, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ country, limit, offset });
         return this.getRequest<NewReleases>(`browse/new-releases${params}`);
     }
 
+    /** @deprecated This endpoint is deprecated by the Spotify Web API. */
     public getFeaturedPlaylists(country?: CountryCodeA2, locale?: string, timestamp?: string, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ country, locale, timestamp, limit, offset });
         return this.getRequest<FeaturedPlaylists>(`browse/featured-playlists${params}`);

--- a/src/endpoints/CurrentUserEndpoints.test.ts
+++ b/src/endpoints/CurrentUserEndpoints.test.ts
@@ -212,6 +212,18 @@ describe("Integration: Users Endpoints (logged in user)", () => {
         await sut.currentUser.playlists.unfollow(result.id);
     });
 
+    it("createPlaylist creates a playlist for the current user", async () => {
+        const result = await sut.currentUser.playlists.createPlaylist({
+            name: "test playlist",
+            description: "test description"
+        });
+
+        expect(fetchSpy.lastRequest().input).toBe("https://api.spotify.com/v1/me/playlists");
+        expect(result.name).toBe("test playlist");
+
+        await sut.currentUser.playlists.unfollow(result.id);
+    });
+
     it("getCurrentUsersPlaylists returns playlists", async () => {
         const result = await sut.currentUser.playlists.playlists();
 

--- a/src/endpoints/CurrentUserEndpoints.test.ts
+++ b/src/endpoints/CurrentUserEndpoints.test.ts
@@ -172,8 +172,10 @@ describe("Integration: Users Endpoints (logged in user)", () => {
 
         await sut.playlists.addCustomPlaylistCoverImage(result.id, file);
         await sut.playlists.addItemsToPlaylist(result.id, [validTrack.uri, validTrack.uri, validTrack.uri, "spotify:track:0ZEigpVOtVunIcimL7dJuh"]);
+        expect(fetchSpy.lastRequest().input).toBe(`https://api.spotify.com/v1/playlists/${result.id}/items`);
 
         const snapshotUpdated = await sut.playlists.movePlaylistItems(result.id, 3, 1, 0); // Move last track to start
+        expect(fetchSpy.lastRequest().input).toBe(`https://api.spotify.com/v1/playlists/${result.id}/items`);
 
         let playlist = await sut.playlists.getPlaylist(result.id);
         expect(playlist.tracks.items.length).toBe(4);
@@ -183,6 +185,7 @@ describe("Integration: Users Endpoints (logged in user)", () => {
             snapshot_id: snapshotUpdated.snapshot_id,
             tracks: [{ uri: validTrack.uri }]
         });
+        expect(fetchSpy.lastRequest().input).toBe(`https://api.spotify.com/v1/playlists/${result.id}/items`);
 
         const playlistWithoutTracks = await sut.playlists.getPlaylist(result.id);
         expect(playlistWithoutTracks.tracks.items.length).toBe(1);

--- a/src/endpoints/CurrentUserEndpoints.ts
+++ b/src/endpoints/CurrentUserEndpoints.ts
@@ -1,6 +1,7 @@
 import { SpotifyApi } from '../SpotifyApi.js';
-import type { User, Page, Artist, Track, MaxInt, FollowedArtists, Market, SavedAlbum, SimplifiedAudiobook, SimplifiedPlaylist, SavedEpisode, SavedShow, SavedTrack, UserProfile } from '../types.js';
+import type { User, Page, Artist, Track, MaxInt, FollowedArtists, Market, Playlist, SavedAlbum, SimplifiedAudiobook, SimplifiedPlaylist, SavedEpisode, SavedShow, SavedTrack, UserProfile } from '../types.js';
 import EndpointsBase from './EndpointsBase.js';
+import type { CreatePlaylistRequest } from './PlaylistsEndpoints.js';
 
 export default class CurrentUserEndpoints extends EndpointsBase {
     public albums: CurrentUserAlbumsEndpoints;
@@ -124,6 +125,10 @@ class CurrentUserPlaylistsEndpoints extends EndpointsBase {
 
     public async unfollow(playlist_id: string) {
         await this.deleteRequest(`playlists/${playlist_id}/followers`);
+    }
+
+    public createPlaylist(request: CreatePlaylistRequest) {
+        return this.postRequest<Playlist>('me/playlists', request);
     }
 
     public isFollowing(playlistId: string, ids: string[]) {

--- a/src/endpoints/PlaylistsEndpoints.test.ts
+++ b/src/endpoints/PlaylistsEndpoints.test.ts
@@ -33,7 +33,7 @@ describe("Integration: Playlists Endpoints", () => {
         const valid = validPlaylist();
         const result = await sut.playlists.getPlaylistItems(valid.id);
 
-        expect(fetchSpy.request(0).input).toBe(`https://api.spotify.com/v1/playlists/${valid.id}/tracks`);
+        expect(fetchSpy.request(0).input).toBe(`https://api.spotify.com/v1/playlists/${valid.id}/items`);
         expect(result.items.length).toBeGreaterThan(0);
     });
 

--- a/src/endpoints/PlaylistsEndpoints.test.ts
+++ b/src/endpoints/PlaylistsEndpoints.test.ts
@@ -41,7 +41,7 @@ describe("Integration: Playlists Endpoints", () => {
         const valid = validPlaylist();
         const result = await sut.playlists.getPlaylistItems(valid.id, undefined, undefined, 1, 0, ['episode']);
 
-        expect(fetchSpy.request(0).input).toBe(`https://api.spotify.com/v1/playlists/${valid.id}/tracks?additional_types=episode`);
+        expect(fetchSpy.request(0).input).toBe(`https://api.spotify.com/v1/playlists/${valid.id}/items?additional_types=episode`);
         expect(result.items.length).toBeGreaterThan(0);
     });
 

--- a/src/endpoints/PlaylistsEndpoints.ts
+++ b/src/endpoints/PlaylistsEndpoints.ts
@@ -16,7 +16,7 @@ export default class PlaylistsEndpoints extends EndpointsBase {
     ) {
         // TODO: better support for fields
         const params = this.paramsFor({ market, fields, limit, offset, additional_types: additional_types?.join(',') });
-        return this.getRequest<Page<PlaylistedTrack<AdditionalTypes extends undefined ? Track : TrackItem>>>(`playlists/${playlist_id}/tracks${params}`);
+        return this.getRequest<Page<PlaylistedTrack<AdditionalTypes extends undefined ? Track : TrackItem>>>(`playlists/${playlist_id}/items${params}`);
     }
 
     public async changePlaylistDetails(playlist_id: string, request: ChangePlaylistDetailsRequest) {
@@ -32,22 +32,24 @@ export default class PlaylistsEndpoints extends EndpointsBase {
     }
 
     public updatePlaylistItems(playlist_id: string, request: UpdatePlaylistItemsRequest) {
-        return this.putRequest<SnapshotReference>(`playlists/${playlist_id}/tracks`, request);
+        return this.putRequest<SnapshotReference>(`playlists/${playlist_id}/items`, request);
     }
 
     public async addItemsToPlaylist(playlist_id: string, uris?: string[], position?: number) {
-        await this.postRequest(`playlists/${playlist_id}/tracks`, { position, uris: uris });
+        await this.postRequest(`playlists/${playlist_id}/items`, { position, uris: uris });
     }
 
     public async removeItemsFromPlaylist(playlist_id: string, request: RemovePlaylistItemsRequest) {
-        await this.deleteRequest(`playlists/${playlist_id}/tracks`, request);
+        await this.deleteRequest(`playlists/${playlist_id}/items`, request);
     }
 
+    /** @deprecated Use `currentUser.playlists.playlists()` instead. */
     public getUsersPlaylists(user_id: string, limit?: MaxInt<50>, offset?: number) {
         const params = this.paramsFor({ limit, offset });
         return this.getRequest<Page<Playlist>>(`users/${user_id}/playlists${params}`);
     }
 
+    /** @deprecated Use `currentUser.playlists.createPlaylist()` instead. */
     public createPlaylist(user_id: string, request: CreatePlaylistRequest) {
         return this.postRequest<Playlist>(`users/${user_id}/playlists`, request);
     }
@@ -108,7 +110,7 @@ interface ChangePlaylistDetailsRequest {
 }
 
 // TODO: deduplicate this from above
-interface CreatePlaylistRequest {
+export interface CreatePlaylistRequest {
     name: string;
     public?: boolean;
     collaborative?: boolean;


### PR DESCRIPTION
## Summary

- Update playlist item endpoints from `/playlists/{id}/tracks` to `/playlists/{id}/items` (GET, POST, PUT, DELETE)
- Add `createPlaylist` method to `CurrentUserPlaylistsEndpoints` using `POST /me/playlists`
- Mark deprecated endpoints with `@deprecated` JSDoc: `getUsersPlaylists`, `createPlaylist` (user_id version), `getFeaturedPlaylists`, `getNewReleases`

## Changes

Addresses the endpoint changes described in [Spotify Web API documentation](https://developer.spotify.com/documentation/web-api/reference):
- `/playlists/{id}/tracks` → `/playlists/{id}/items`
- `POST /users/{id}/playlists` → `POST /me/playlists`

## Result

The SDK now uses the current Spotify Web API endpoints for playlist operations. Deprecated methods remain available with `@deprecated` annotations to avoid breaking existing consumers.

Closes #155




### This PR only covers a subset of the February 2026 API changes. The following changes are not yet addressed:

Library endpoints consolidation (/me/tracks, /me/albums, etc. → /me/library)
Follow endpoints consolidation (/me/following, /playlists/{id}/followers → /me/library)
Contains endpoints consolidation → /me/library/contains
Batch endpoints removal (GET /tracks, /albums, /artists, etc.)
Playlist response field renames (tracks → items, tracks.track → items.item)
Removed fields (popularity, available_markets, followers, etc.)
Search limit max reduced from 50 to 10

https://developer.spotify.com/documentation/web-api/references/changes/february-2026
https://developer.spotify.com/documentation/web-api/references/changes/march-2026