### PR TITLE
fix: Mark `item` as nullable in `PlaybackState`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -678,7 +678,7 @@ export interface PlaybackState {
     timestamp: number
     progress_ms: number
     is_playing: boolean
-    item: TrackItem
+    item: TrackItem | null
     currently_playing_type: string
     actions: Actions
 }


### PR DESCRIPTION
<!-- See: CONTRIBUTING.md#Pull-Requests -->

### Summary

<!-- Explain the context and why you're making that change.  What is the problem you're trying to solve? -->

From the [Spotify API docs for Get Playback State](https://developer.spotify.com/documentation/web-api/reference/get-information-about-the-users-current-playback#:~:text=oneOf-,The%20currently%20playing%20track%20or%20episode.%20Can%20be%20null,-.)

> item - oneOf
> The currently playing track or episode. Can be null

### Changes

<!-- Describe the solution and changes that you have made -->

In the `PlaybackState` interface, `type` is now corrected to be `TrackItem | null` rather than just `TrackItem`

### Results

<!-- Describe expected new behaviour, as well as any steps on how to test / verify. -->
